### PR TITLE
14 feat letter 리스트 조회 페이징 도입

### DIFF
--- a/back/src/main/java/com/back/letter/controller/LetterController.java
+++ b/back/src/main/java/com/back/letter/controller/LetterController.java
@@ -36,21 +36,34 @@ public class LetterController {
 
     @GetMapping("/received")
     public ResponseEntity<RsData<LetterListRes>> getReceivedLetters(
-            @RequestHeader("User-Id") Member userId
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
-        LetterListRes data = letterService.getMyInbox(userId);
+        int memberId = 2;
+        LetterListRes data = letterService.getMyInbox(memberId, page, size);
         return ResponseEntity.ok(new RsData<>("200-2", "받은 편지 보관함 조회 성공", data));
+    }
+
+    @GetMapping("/sent")
+    public ResponseEntity<RsData<LetterListRes>> getSentLetters(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        int memberId = 1;
+
+        LetterListRes data = letterService.getMySentBox(memberId, page, size);
+        return ResponseEntity.ok(new RsData<>("200-3", "보낸 편지 보관함 조회 성공", data));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<RsData<LetterInfoRes>> getDetail(@PathVariable int id){
         LetterInfoRes data = letterService.getLetter(id);
-        return ResponseEntity.ok(new RsData<>("200-3","편지 상세 조회 성공", data));
+        return ResponseEntity.ok(new RsData<>("200-4","편지 상세 조회 성공", data));
     }
 
     @PostMapping("/{id}/reply")
     public ResponseEntity<RsData<Void>> reply(@PathVariable int id, @RequestBody @Valid ReplyLetterReq req){
         letterService.replyLetter(id, req);
-        return ResponseEntity.ok(new RsData<>("200-4", "답장이 등록되었습니다."));
+        return ResponseEntity.ok(new RsData<>("200-5", "답장이 등록되었습니다."));
     }
 }

--- a/back/src/main/java/com/back/letter/dto/LetterListRes.java
+++ b/back/src/main/java/com/back/letter/dto/LetterListRes.java
@@ -1,8 +1,25 @@
 package com.back.letter.dto;
 
+import org.springframework.data.domain.Page;
+
 import java.util.List;
 
 public record LetterListRes(
-    List<LetterItem> letters
+    List<LetterItem> letters,
+    int totalPages,
+    long totalElements,
+    int currentPage,
+    boolean isFirst,
+    boolean isLast
 ) {
+    public static LetterListRes from(Page<LetterItem> page){
+        return new LetterListRes(
+                page.getContent(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.getNumber(),
+                page.isFirst(),
+                page.isLast()
+        );
+    }
 }

--- a/back/src/main/java/com/back/letter/repository/LetterRepository.java
+++ b/back/src/main/java/com/back/letter/repository/LetterRepository.java
@@ -2,6 +2,8 @@ package com.back.letter.repository;
 
 import com.back.letter.entity.Letter;
 import com.back.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,8 +13,12 @@ import java.util.Optional;
 
 public interface LetterRepository extends JpaRepository<Letter, Integer> {
 
+    @Query("SELECT l FROM Letter l JOIN FETCH l.sender WHERE l.receiver.id = :memberId")
+    Page<Letter> findByReceiverId(@Param("memberId") Integer memberId, Pageable pageable);
 
-    List<Letter> findByReceiverOrderByCreateDateDesc(Member receiver);
+    @Query("SELECT l FROM Letter l JOIN FETCH l.receiver WHERE l.sender.id = :memberId")
+    Page<Letter> findBySenderId(@Param("memberId") Integer memberId, Pageable pageable);
+
     @Query(value = "SELECT * FROM members " +
             "WHERE id != :myId AND status = 'ACTIVE' " +
             "ORDER BY RANDOM() LIMIT 1",

--- a/back/src/main/java/com/back/letter/service/LetterService.java
+++ b/back/src/main/java/com/back/letter/service/LetterService.java
@@ -9,6 +9,10 @@ import com.back.letter.repository.LetterRepository;
 import com.back.member.domain.Member;
 import com.back.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,25 +82,23 @@ public class LetterService {
         letter.reply(req.replyContent());
     }
 
+    // 나에게 온 편지 보관함 조회
+    public LetterListRes getMyInbox(int memberId, int page, int size) {
+        return getLetterList(page, size, letterRepository.findByReceiverId(memberId, getPageable(page, size)));
+    }
 
-    /*
-     [나에게 온 편지 보관함 조회]
-     내가 수신자(receiverId)로 지정된 모든 편지 목록을 최신순으로 가져옴
-     */
-    @Transactional(readOnly = true)
-    public LetterListRes getMyInbox(Member userId) {
+    // 내가 보낸 편지 보관함 조회
+    public LetterListRes getMySentBox(int memberId, int page, int size) {
+        return getLetterList(page, size, letterRepository.findBySenderId(memberId, getPageable(page, size)));
+    }
 
-        // 1. 리포지토리를 통해 나에게 온 편지 엔티티 리스트 조회
-        List<Letter> letters = letterRepository.findByReceiverOrderByCreateDateDesc(userId);
+    // 공통 정렬 로직 추출
+    private Pageable getPageable(int page, int size) {
+        return PageRequest.of(page, size, Sort.by("id").descending());
+    }
 
-
-        // 2. 엔티티 리스트를 클라이언트 응답용 DTO(LetterItem) 리스트로 변환
-        List<LetterItem> items = letters.stream()
-                .map(LetterItem::from)
-                .toList();
-
-
-        // 3. 최종 응답 객체(LetterListRes) 생성 후 반환
-        return new LetterListRes(items);
+    // 공통 변환 로직 추출
+    private LetterListRes getLetterList(int page, int size, Page<Letter> letterPage) {
+        return LetterListRes.from(letterPage.map(LetterItem::from));
     }
 }


### PR DESCRIPTION
## 🔗 Issue 번호
- close #14 

## 🛠 작업 내역
-페이징 시스템 도입: 대량의 편지 데이터를 효율적으로 처리하기 위해 Pageable을 적용했습니다.

## 🔄 변경 사항
-LetterController: 목록 조회 API(received, sent)에 page와 size 파라미터를 추가하고 기본값(0, 10)을 설정했습니다.

-LetterService: 기존 리스트 반환 방식에서 Page 객체를 활용한 DTO 변환 방식으로 로직을 전면 수정했습니다.

-LetterListRes: 페이징 정보(totalPages, totalElements, isFirst, isLast 등) 필드를 새롭게 추가했습니다.

## ✨ 새로운 기능
- 보낸 편지함 조회 API: 내가 작성한 편지들을 최신순으로 모아볼 수 있는 /api/v1/letters/sent 엔드포인트를 추가했습니다.

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

