### PR TITLE
[Feat] diary 도메인 구현

### DIFF
--- a/back/src/main/java/com/back/diary/controller/DiaryController.java
+++ b/back/src/main/java/com/back/diary/controller/DiaryController.java
@@ -1,0 +1,54 @@
+package com.back.diary.controller;
+
+import com.back.diary.dto.DiaryCreateReq;
+import com.back.diary.dto.DiaryRes;
+import com.back.diary.service.DiaryService;
+import com.back.global.rsData.RsData;
+import com.back.global.security.adapter.in.AuthenticatedMember;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/diaries")
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final DiaryService diaryService;
+
+    @PostMapping
+    public RsData<Long> create(
+            @Valid @RequestBody DiaryCreateReq req,
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+    ) {
+        Long diaryId = diaryService.write(
+                req,
+                authenticatedMember.memberId()
+        );
+
+        return new RsData<>("201-1", "일기가 저장되었습니다.", diaryId);
+    }
+
+
+    @GetMapping("/{id}")
+    public RsData<DiaryRes> getOne(
+            @PathVariable Long id,
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+    ) {
+        DiaryRes diaryRes = diaryService.getDiary(id, authenticatedMember.memberId());
+
+        return new RsData<>("200-1", "일기를 불러왔습니다.", diaryRes);
+    }
+
+    @GetMapping
+    public RsData<List<DiaryRes>> getMyList(
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+    ) {
+        List<DiaryRes> myDiaries = diaryService.getMyDiaries(authenticatedMember.memberId());
+
+        return new RsData<>("200-2", "일기들을 가져왔습니다.", myDiaries);
+    }
+}

--- a/back/src/main/java/com/back/diary/dto/DiaryCreateReq.java
+++ b/back/src/main/java/com/back/diary/dto/DiaryCreateReq.java
@@ -1,0 +1,26 @@
+package com.back.diary.dto;
+
+import com.back.diary.entity.Diary;
+import jakarta.validation.constraints.NotBlank;
+
+public record DiaryCreateReq(
+    @NotBlank(message = "제목을 입력해주세요.")
+    String title,
+    
+    @NotBlank(message = "내용을 입력해주세요.")
+    String content,
+    
+    @NotBlank(message = "카테고리를 선택해주세요.")
+    String categoryName
+) {
+    // Service 계층에서 엔티티로 변환할 때 사용
+    public Diary toEntity(Long memberId) {
+        return Diary.builder()
+            .memberId(memberId)
+//            .nickname(nickname)
+            .title(title)
+            .content(content)
+            .categoryName(categoryName)
+            .build();
+    }
+}

--- a/back/src/main/java/com/back/diary/dto/DiaryListRes.java
+++ b/back/src/main/java/com/back/diary/dto/DiaryListRes.java
@@ -1,0 +1,21 @@
+package com.back.diary.dto;
+
+import com.back.diary.entity.Diary;
+
+import java.time.LocalDateTime;
+
+public record DiaryListRes(
+    Long id,
+    String title,
+    String categoryName,
+    LocalDateTime createdDate
+) {
+    public static DiaryListRes from(Diary diary) {
+        return new DiaryListRes(
+            diary.getId(),
+            diary.getTitle(),
+            diary.getCategoryName(),
+            diary.getCreateDate()
+        );
+    }
+}

--- a/back/src/main/java/com/back/diary/dto/DiaryRes.java
+++ b/back/src/main/java/com/back/diary/dto/DiaryRes.java
@@ -1,0 +1,25 @@
+package com.back.diary.dto;
+
+import com.back.diary.entity.Diary;
+
+import java.time.LocalDateTime;
+
+public record DiaryRes(
+    Long id,
+    String title,
+    String content,
+    String categoryName,
+    String nickname,
+    LocalDateTime createDate
+) {
+    public static DiaryRes from(Diary diary) {
+        return new DiaryRes(
+            diary.getId(),
+            diary.getTitle(),
+            diary.getContent(),
+            diary.getCategoryName(),
+            diary.getNickname(),
+                diary.getCreateDate()
+        );
+    }
+}

--- a/back/src/main/java/com/back/diary/entity/Diary.java
+++ b/back/src/main/java/com/back/diary/entity/Diary.java
@@ -1,0 +1,46 @@
+package com.back.diary.entity;
+
+import com.back.global.jpa.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Diary extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long memberId; // 작성자 식별값
+
+    @Column(nullable = true) // 닉네임을 사용하지 않을 경우 null 허용
+    private String nickname;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private String categoryName;
+
+    // 일기장은 기본적으로 비공개(true)로 설정
+    @Column(nullable = false)
+    private boolean isPrivate = true;
+
+    @Builder
+    public Diary(Long memberId, String nickname, String title, String content, String categoryName) {
+        this.memberId = memberId;
+        this.nickname = (nickname == null) ? "익명" : nickname;
+        this.nickname = nickname;
+        this.title = title;
+        this.content = content;
+        this.categoryName = categoryName;
+    }
+}

--- a/back/src/main/java/com/back/diary/repository/DiaryRepository.java
+++ b/back/src/main/java/com/back/diary/repository/DiaryRepository.java
@@ -1,0 +1,11 @@
+package com.back.diary.repository;
+
+import com.back.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findAllByMemberIdOrderByCreateDateDesc(Long memberId);
+
+}

--- a/back/src/main/java/com/back/diary/service/DiaryService.java
+++ b/back/src/main/java/com/back/diary/service/DiaryService.java
@@ -1,0 +1,46 @@
+package com.back.diary.service;
+
+import com.back.diary.dto.DiaryCreateReq;
+import com.back.diary.dto.DiaryRes;
+import com.back.diary.entity.Diary;
+import com.back.diary.repository.DiaryRepository;
+import com.back.global.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    @Transactional
+    public Long write(DiaryCreateReq req, Long memberId) {
+        Diary diary = req.toEntity(memberId);
+        return diaryRepository.save(diary).getId();
+    }
+
+    /** 일기 단건 조회 (보안 체크 포함) */
+    public DiaryRes getDiary(Long diaryId, Long currentMemberId) {
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
+
+        if (!diary.getMemberId().equals(currentMemberId)) {
+            // 보안상 403 대신 404를 던져 해당 리소스의 존재 유무를 숨길 수 있습니다.
+            throw new ServiceException("404-1", "존재하지 않는 일기입니다.");
+        }
+
+        return DiaryRes.from(diary);
+    }
+
+    public List<DiaryRes> getMyDiaries(Long memberId) {
+        return diaryRepository.findAllByMemberIdOrderByCreateDateDesc(memberId)
+                .stream()
+                .map(DiaryRes::from) // Entity -> DTO 변환
+                .toList();
+    }
+}

--- a/back/src/main/java/com/back/global/webMvc/WebMvcConfig.java
+++ b/back/src/main/java/com/back/global/webMvc/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.back.global.webMvc;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000", "https://cdpn.io")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/front/src/app/letters/mailbox/page.tsx
+++ b/front/src/app/letters/mailbox/page.tsx
@@ -1,0 +1,155 @@
+// app/letters/mailbox/page.tsx
+"use client";
+
+import React, { useState } from "react";
+import {
+  Mail,
+  Send,
+  Heart,
+  Droplets,
+  ChevronRight,
+  Inbox,
+  Waves,
+} from "lucide-react";
+
+type MailboxTab = "received" | "sent";
+
+export default function MailboxPage() {
+  const [activeTab, setActiveTab] = useState<MailboxTab>("received");
+
+  return (
+    <div className="min-h-screen bg-[#EBF5FF] text-slate-800 flex flex-col font-sans selection:bg-blue-100">
+      {/* 1. Header (이미지 상단바 참고) */}
+      <header className="flex items-center justify-between px-8 py-4 bg-white/50 backdrop-blur-md sticky top-0 z-50">
+        <div className="flex items-center gap-2">
+          <div className="w-8 h-8 bg-sky-400 rounded-lg flex items-center justify-center text-white">
+            <Waves size={20} />
+          </div>
+          <span className="text-xl font-bold text-sky-900">마음온</span>
+        </div>
+        <nav className="hidden md:flex items-center gap-8 text-sm font-semibold text-slate-500">
+          <button className="hover:text-sky-500">홈</button>
+          <button className="text-sky-600 border-b-2 border-sky-500 pb-1">
+            편지함
+          </button>
+          <button className="hover:text-sky-500">커뮤니티</button>
+        </nav>
+        <div className="flex gap-4">
+          <div className="w-8 h-8 rounded-full bg-sky-100 border border-sky-200" />
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto w-full px-6 py-12 flex flex-col items-center">
+        {/* 2. Tab Selector */}
+        <div className="bg-white/40 p-1.5 rounded-2xl flex gap-2 mb-10 shadow-sm">
+          <button
+            onClick={() => setActiveTab("received")}
+            className={`px-8 py-2.5 rounded-xl text-sm font-bold transition-all ${
+              activeTab === "received"
+                ? "bg-white text-sky-600 shadow-md"
+                : "text-slate-500 hover:text-sky-400"
+            }`}
+          >
+            받은 편지함
+          </button>
+          <button
+            onClick={() => setActiveTab("sent")}
+            className={`px-8 py-2.5 rounded-xl text-sm font-bold transition-all ${
+              activeTab === "sent"
+                ? "bg-white text-sky-600 shadow-md"
+                : "text-slate-500 hover:text-sky-400"
+            }`}
+          >
+            보낸 편지함
+          </button>
+        </div>
+
+        {/* 3. Main Highlight Card (이미지 중앙 카드 참고) */}
+        <section className="w-full max-w-md mb-16 animate-in fade-in slide-in-from-bottom-4 duration-700">
+          <div className="bg-white/80 backdrop-blur-xl rounded-[3rem] p-10 shadow-[0_20px_50px_-12px_rgba(0,0,0,0.05)] border border-white flex flex-col items-center text-center">
+            <span className="text-xs font-bold text-sky-400 bg-sky-50 px-3 py-1 rounded-full mb-6">
+              {activeTab === "received"
+                ? "따뜻한 연결의 시작"
+                : "나의 진심을 담은 기록"}
+            </span>
+            <h2 className="text-3xl font-bold text-slate-800 mb-2">
+              {activeTab === "received"
+                ? "편지가 도착했습니다"
+                : "파도에 실어 보낸 마음"}
+            </h2>
+            <p className="text-slate-500 text-sm leading-relaxed mb-10">
+              {activeTab === "received"
+                ? "누군가의 소중한 진심이 담긴 편지가\n당신의 마음을 두드리고 있어요."
+                : "당신이 보낸 편지들이 바다 너머\n누군가에게 따뜻한 위로가 되고 있을 거예요."}
+            </p>
+
+            <div className="relative w-32 h-32 bg-sky-50 rounded-full flex items-center justify-center mb-10 shadow-inner group cursor-pointer hover:scale-105 transition-transform">
+              <div className="absolute inset-0 bg-sky-400/10 rounded-full animate-ping opacity-20" />
+              {activeTab === "received" ? (
+                <Mail size={48} className="text-sky-400" />
+              ) : (
+                <Send size={48} className="text-sky-400" />
+              )}
+            </div>
+
+            <button className="text-sky-500 font-bold flex items-center gap-2 hover:gap-3 transition-all">
+              {activeTab === "received" ? "편지 열어보기" : "보낸 기록 보기"}
+              <ChevronRight size={18} />
+            </button>
+
+            {/* Pagination Dots */}
+            <div className="flex gap-2 mt-8">
+              <div className="w-6 h-1.5 bg-sky-400 rounded-full" />
+              <div className="w-1.5 h-1.5 bg-sky-100 rounded-full" />
+              <div className="w-1.5 h-1.5 bg-sky-100 rounded-full" />
+            </div>
+          </div>
+        </section>
+
+        {/* 4. Sub List Cards (이미지 하단 카드 3개 참고) */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full">
+          {/* Card 1 */}
+          <div className="bg-white/60 backdrop-blur-md p-6 rounded-[2rem] flex items-center gap-4 hover:bg-white transition-colors cursor-pointer border border-white/40 shadow-sm group">
+            <div className="w-12 h-12 bg-sky-50 rounded-2xl flex items-center justify-center text-sky-400 group-hover:bg-sky-400 group-hover:text-white transition-colors">
+              <Droplets size={24} />
+            </div>
+            <div>
+              <p className="text-slate-400 text-xs font-bold">
+                최근 {activeTab === "received" ? "받은" : "보낸"} 편지
+              </p>
+              <p className="text-slate-700 font-bold">
+                3일 전 {activeTab === "received" ? "도착" : "발송"}
+              </p>
+            </div>
+          </div>
+
+          {/* Card 2 */}
+          <div className="bg-white/60 backdrop-blur-md p-6 rounded-[2rem] flex items-center gap-4 hover:bg-white transition-colors cursor-pointer border border-white/40 shadow-sm group">
+            <div className="w-12 h-12 bg-rose-50 rounded-2xl flex items-center justify-center text-rose-400 group-hover:bg-rose-400 group-hover:text-white transition-colors">
+              <Heart size={24} />
+            </div>
+            <div>
+              <p className="text-slate-400 text-xs font-bold">나의 보관함</p>
+              <p className="text-slate-700 font-bold">12통의 진심</p>
+            </div>
+          </div>
+
+          {/* Card 3 */}
+          <div className="bg-white/60 backdrop-blur-md p-6 rounded-[2rem] flex items-center gap-4 hover:bg-white transition-colors cursor-pointer border border-white/40 shadow-sm group">
+            <div className="w-12 h-12 bg-emerald-50 rounded-2xl flex items-center justify-center text-emerald-400 group-hover:bg-emerald-400 group-hover:text-white transition-colors">
+              <Send size={24} />
+            </div>
+            <div>
+              <p className="text-slate-400 text-xs font-bold">새 편지 쓰기</p>
+              <p className="text-slate-700 font-bold">마음을 전하세요</p>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <footer className="mt-auto py-8 text-center text-slate-400 text-[10px] tracking-widest uppercase">
+        © 2026 MAUM-ON. ALL RIGHTS RESERVED.
+      </footer>
+    </div>
+  );
+}

--- a/front/src/app/letters/mailbox/receive/[id]/page.tsx
+++ b/front/src/app/letters/mailbox/receive/[id]/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import {
+  ChevronLeft,
+  Calendar,
+  MailOpen,
+  Waves,
+  Heart,
+  Send,
+  MessageSquareText,
+} from "lucide-react";
+import { requestData, requestVoid } from "@/lib/api/http-client";
+
+interface ReceivedLetterDetail {
+  id: number;
+  title: string;
+  content: string;
+  createdDate: string;
+  senderNickname: string;
+  replied: boolean;
+  replyContent?: string;
+}
+
+export default function ReceivedLetterDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const [letter, setLetter] = useState<ReceivedLetterDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [replyContent, setReplyContent] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchLetterDetail = async () => {
+      try {
+        const data = await requestData<ReceivedLetterDetail>(
+          `/api/v1/letters/${params.id}`,
+        );
+        setLetter(data);
+      } catch (error) {
+        console.error("편지를 가져오는데 실패했습니다.", error);
+        alert("존재하지 않는 편지입니다.");
+        router.back();
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchLetterDetail();
+  }, [params.id, router]);
+
+  // 답장 전송 함수
+  const handleReplySubmit = async () => {
+    if (!replyContent.trim()) {
+      alert("답장 내용을 입력해주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await requestVoid(`/api/v1/letters/received/${params.id}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: replyContent }),
+      });
+      alert("답장이 바다로 전송되었습니다.");
+      router.refresh(); // 데이터 갱신
+      window.location.reload(); // 상태 업데이트를 위해 새로고침
+    } catch (error) {
+      console.error("답장 전송 실패:", error);
+      alert("답장 전송에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-[#EBF5FF] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-sky-400"></div>
+      </div>
+    );
+  }
+
+  if (!letter) return null;
+
+  return (
+    <div className="min-h-screen bg-[#EBF5FF] text-slate-800 font-sans pb-20">
+      <header className="p-6 flex items-center justify-between max-w-6xl mx-auto w-full sticky top-0 z-50">
+        <button
+          onClick={() => router.back()}
+          className="p-3 bg-white/60 hover:bg-white rounded-full transition-all text-slate-500 shadow-sm"
+        >
+          <ChevronLeft size={24} />
+        </button>
+        <h1 className="text-xl font-bold text-sky-900 flex items-center gap-2.5">
+          <MailOpen size={22} className="text-sky-400" />
+          도착한 마음
+        </h1>
+        <div className="w-12" />
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 mt-10">
+        {/* 원본 편지 카드 */}
+        <section className="bg-white/90 backdrop-blur-md rounded-[3rem] p-10 md:p-14 shadow-[0_30px_70px_-15px_rgba(186,215,233,0.6)] border border-white relative overflow-hidden">
+          <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-sky-100 via-sky-300 to-sky-100" />
+
+          <div className="flex justify-between items-center mb-12 border-b border-slate-100 pb-8 text-slate-400 text-sm italic font-serif">
+            <span>From. {letter.senderNickname || "익명의 누군가"}</span>
+            <div className="flex items-center gap-2 not-italic font-sans font-medium bg-slate-50 px-4 py-1.5 rounded-full">
+              <Calendar size={16} className="text-sky-300" />
+              {new Date(letter.createdDate).toLocaleDateString()}
+            </div>
+          </div>
+
+          <div className="mb-10">
+            <h2 className="text-3xl font-bold text-slate-900 mb-8 leading-tight">
+              {letter.title}
+            </h2>
+            <div className="text-slate-700 text-xl leading-relaxed font-serif whitespace-pre-wrap italic">
+              {letter.content}
+            </div>
+          </div>
+
+          <div className="pt-8 border-t border-slate-50 flex justify-end">
+            <Waves size={24} className="text-sky-100" />
+          </div>
+        </section>
+
+        {/* 답장 영역 */}
+        <section className="mt-12">
+          {letter.replied ? (
+            // 이미 답장을 보낸 경우
+            <div className="bg-emerald-50/60 backdrop-blur-md rounded-[2.5rem] p-10 border border-emerald-100">
+              <div className="flex items-center gap-3 mb-6 text-emerald-700 font-bold">
+                <Heart size={20} />
+                <span>내가 보낸 따뜻한 답장</span>
+              </div>
+              <div className="text-slate-700 text-lg leading-relaxed font-serif italic whitespace-pre-wrap">
+                {letter.replyContent}
+              </div>
+            </div>
+          ) : (
+            // 아직 답장을 보내지 않은 경우 (입력창)
+            <div className="bg-white/60 backdrop-blur-md rounded-[3rem] p-8 md:p-10 border border-white shadow-lg">
+              <div className="flex items-center gap-3 mb-6 text-sky-700 font-bold">
+                <MessageSquareText size={20} />
+                <span>이 편지에 답장을 남겨보세요</span>
+              </div>
+
+              <textarea
+                value={replyContent}
+                onChange={(e) => setReplyContent(e.target.value)}
+                placeholder="따뜻한 말 한마디가 누군가에게 큰 힘이 됩니다..."
+                className="w-full h-48 bg-white/50 rounded-2xl p-6 text-lg font-serif italic outline-none focus:ring-2 ring-sky-200 border border-slate-100 transition-all resize-none placeholder:text-slate-300"
+              />
+
+              <div className="mt-6 flex justify-end">
+                <button
+                  onClick={handleReplySubmit}
+                  disabled={isSubmitting || !replyContent.trim()}
+                  className={`flex items-center gap-2 px-8 py-4 rounded-full font-bold transition-all shadow-lg active:scale-95
+                    ${
+                      isSubmitting || !replyContent.trim()
+                        ? "bg-slate-200 text-slate-400 cursor-not-allowed"
+                        : "bg-sky-500 text-white hover:bg-sky-600 shadow-sky-200"
+                    }`}
+                >
+                  {isSubmitting ? "전송 중..." : "답장 띄워보내기"}
+                  <Send size={18} />
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/front/src/app/letters/mailbox/receive/page.tsx
+++ b/front/src/app/letters/mailbox/receive/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Inbox,
+  ChevronLeft,
+  MessageSquare,
+  Sparkles,
+  Waves,
+  Clock,
+  CheckCircle2,
+} from "lucide-react";
+import { requestData } from "@/lib/api/http-client";
+
+interface ReceivedLetter {
+  id: number;
+  title: string;
+  content: string;
+  senderNickname: string;
+  read: boolean;
+  createdDate: string;
+}
+
+export default function ReceivedLettersPage() {
+  const router = useRouter();
+  const [letters, setLetters] = useState<ReceivedLetter[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchReceivedLetters = async () => {
+      try {
+        const response = await requestData<any>("/api/v1/letters/received");
+        // 페이징 처리된 경우 response.letters, 아니면 response 자체 사용
+        const data = Array.isArray(response)
+          ? response
+          : response?.letters || [];
+        setLetters(data);
+      } catch (error) {
+        console.error("받은 편지를 가져오는데 실패했습니다.", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchReceivedLetters();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#EBF5FF] text-slate-800 font-sans pb-20">
+      {/* 상단 네비게이션 */}
+      <header className="p-6 flex items-center justify-between max-w-6xl mx-auto w-full">
+        <button
+          onClick={() => router.push("/")}
+          className="p-2 hover:bg-white/50 rounded-full transition-all text-slate-500 active:scale-95"
+        >
+          <ChevronLeft size={28} />
+        </button>
+        <h1 className="text-xl font-bold text-sky-900 flex items-center gap-2">
+          <Inbox size={22} className="text-sky-400" />
+          받은 편지함
+        </h1>
+        <div className="w-10" />
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 mt-8">
+        {/* 요약 카드: 받은 편지만의 감성 문구 */}
+        <section className="bg-white/70 backdrop-blur-lg rounded-[2.5rem] p-8 mb-12 flex flex-col md:flex-row items-center justify-between border border-white/50 shadow-sm">
+          <div className="text-center md:text-left">
+            <h2 className="text-2xl font-bold text-slate-800 mb-2 flex items-center justify-center md:justify-start gap-2">
+              누군가의 진심이 도착했어요{" "}
+              <Sparkles size={24} className="text-amber-400" />
+            </h2>
+            <p className="text-slate-500">
+              바다를 건너 당신에게 닿은 {letters.length}개의 소중한
+              이야기입니다.
+            </p>
+          </div>
+          <div className="mt-6 md:mt-0 p-5 bg-gradient-to-br from-sky-400 to-blue-500 text-white rounded-[2rem] shadow-lg shadow-sky-200">
+            <Inbox size={32} />
+          </div>
+        </section>
+
+        {/* 편지 목록 */}
+        {isLoading ? (
+          <div className="flex flex-col items-center py-20 gap-4">
+            <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-sky-400"></div>
+          </div>
+        ) : letters.length === 0 ? (
+          <div className="text-center py-24 bg-white/20 rounded-[3rem] border-2 border-dashed border-sky-200/50">
+            <p className="text-slate-400 text-lg italic font-serif">
+              아직 바닷가에 떠밀려온 편지가 없네요...
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {letters.map((letter) => (
+              <div
+                key={letter.id}
+                onClick={() =>
+                  router.push(`/letters/mailbox/receive/${letter.id}`)
+                }
+                className={`group relative p-8 rounded-[2.5rem] border transition-all duration-300 cursor-pointer hover:-translate-y-2
+                  ${
+                    letter.read
+                      ? "bg-white/40 border-white/20 grayscale-[0.3]"
+                      : "bg-white shadow-[0_20px_40px_-15px_rgba(0,0,0,0.05)] border-white animate-pulse-subtle"
+                  }`}
+              >
+                {/* 읽음/안읽음 상태 표시 */}
+                <div className="flex justify-between items-start mb-6">
+                  <div className="flex items-center gap-2 text-[11px] font-bold text-slate-400 bg-slate-100/50 px-3 py-1.5 rounded-full uppercase">
+                    <Clock size={14} />
+                    {new Date(letter.createdDate).toLocaleDateString()}
+                  </div>
+                  {!letter.read && (
+                    <span className="flex items-center gap-1 text-[11px] font-black text-white bg-rose-400 px-3 py-1.5 rounded-full shadow-md shadow-rose-100 animate-bounce">
+                      NEW
+                    </span>
+                  )}
+                  {letter.read && (
+                    <CheckCircle2 size={18} className="text-sky-300" />
+                  )}
+                </div>
+
+                {/* 제목 및 미리보기 */}
+                <h3
+                  className={`text-xl font-bold mb-3 line-clamp-1 ${letter.read ? "text-slate-500" : "text-slate-800"}`}
+                >
+                  {letter.title}
+                </h3>
+                <p className="text-slate-400 text-sm leading-relaxed line-clamp-2 font-serif mb-8">
+                  {letter.content}
+                </p>
+
+                {/* 하단 보낸 이 정보 */}
+                <div className="pt-6 border-t border-slate-100 flex justify-between items-center text-slate-400">
+                  <div className="flex items-center gap-2">
+                    <div className="w-7 h-7 bg-sky-100 rounded-full flex items-center justify-center text-sky-500">
+                      <MessageSquare size={14} />
+                    </div>
+                    <span className="text-xs font-medium">
+                      From. {letter.senderNickname || "익명의 파도"}
+                    </span>
+                  </div>
+                  <Waves
+                    size={16}
+                    className="text-sky-200 group-hover:text-sky-400 transition-colors"
+                  />
+                </div>
+
+                {/* 읽지 않은 편지 강조 효과 */}
+                {!letter.read && (
+                  <div className="absolute inset-0 rounded-[2.5rem] ring-2 ring-sky-300/30 pointer-events-none"></div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/front/src/app/letters/mailbox/sent/[id]/page.tsx
+++ b/front/src/app/letters/mailbox/sent/[id]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import {
+  ChevronLeft,
+  Calendar,
+  Send,
+  MailOpen,
+  Waves,
+  Heart,
+  MessageCircle,
+} from "lucide-react";
+import { requestData } from "@/lib/api/http-client";
+
+interface SentLetterDetail {
+  id: number;
+  title: string;
+  content: string;
+  createdDate: string;
+  replied: boolean;
+  replyContent?: string;
+  replyDate?: string;
+}
+
+export default function SentLetterDetailPage() {
+  const router = useRouter();
+  const params = useParams(); // URL에서 [id]를 가져옵니다.
+  const [letter, setLetter] = useState<SentLetterDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 1. 데이터 불러오기
+  useEffect(() => {
+    const fetchLetterDetail = async () => {
+      try {
+        const data = await requestData<SentLetterDetail>(
+          `/api/v1/letters/${params.id}`,
+        );
+        setLetter(data);
+      } catch (error) {
+        console.error("편지 상세 내용을 가져오는데 실패했습니다.", error);
+        alert("편지를 찾을 수 없습니다.");
+        router.back();
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchLetterDetail();
+  }, [params.id, router]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-[#EBF5FF] flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-sky-400"></div>
+      </div>
+    );
+  }
+
+  if (!letter) return null;
+
+  return (
+    <div className="min-h-screen bg-[#EBF5FF] text-slate-800 font-sans pb-20">
+      {/* 1. Header (네비게이션) */}
+      <header className="p-6 flex items-center justify-between max-w-6xl mx-auto w-full sticky top-0 z-50">
+        <button
+          onClick={() => router.back()}
+          className="p-3 bg-white/60 hover:bg-white rounded-full transition-all text-slate-500 shadow-sm active:scale-95"
+        >
+          <ChevronLeft size={24} />
+        </button>
+        <h1 className="text-xl font-bold text-sky-900 flex items-center gap-2.5">
+          <MailOpen size={22} className="text-sky-400" />
+          마음의 흔적
+        </h1>
+        <div className="w-12" /> {/* 밸런스를 위한 빈 공간 */}
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 mt-10">
+        {/* 2. 메인 편지 카드 (첫 번째 이미지의 양피지 느낌) */}
+        <section className="bg-white/90 backdrop-blur-md rounded-[3rem] p-10 md:p-14 shadow-[0_30px_70px_-15px_rgba(186,215,233,0.6)] border border-white flex flex-col relative overflow-hidden animate-in fade-in slide-in-from-bottom-6 duration-700">
+          {/* 상단 장식 라인 */}
+          <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-sky-100 via-sky-300 to-sky-100" />
+
+          {/* 편지 메타 정보 */}
+          <div className="flex justify-between items-center mb-12 border-b border-slate-100 pb-8 text-slate-400 text-sm italic font-serif">
+            <span>To. 바다 건너 누군가</span>
+            <div className="flex items-center gap-2 not-italic font-sans font-medium bg-slate-50 px-4 py-1.5 rounded-full">
+              <Calendar size={16} className="text-sky-300" />
+              {new Date(letter.createdDate).toLocaleDateString("ko-KR", {
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+              })}
+            </div>
+          </div>
+
+          {/* 편지 내용 */}
+          <div className="flex-grow">
+            <h2 className="text-3xl font-bold text-slate-900 mb-8 leading-tight">
+              {letter.title}
+            </h2>
+            <div className="text-slate-700 text-xl leading-relaxed font-serif whitespace-pre-wrap italic">
+              {letter.content}
+            </div>
+          </div>
+
+          {/* 하단 서명 (두 번째 이미지의 하단 카드 느낌) */}
+          <div className="mt-16 pt-10 border-t border-slate-100 flex justify-between items-center">
+            <div className="text-sm text-slate-400 flex items-center gap-2">
+              <Heart size={16} className="text-rose-300" />
+              진심을 담아, 마음온
+            </div>
+            <div className="w-10 h-10 rounded-full bg-sky-50 flex items-center justify-center text-sky-400">
+              <Waves size={20} />
+            </div>
+          </div>
+        </section>
+
+        {/* 3. 답장 섹션 (답장이 있을 때만 표시) */}
+        {letter.replied && letter.replyContent && (
+          <section className="mt-12 bg-emerald-50/50 backdrop-blur-sm rounded-[2.5rem] p-8 border border-emerald-100/50 animate-in fade-in zoom-in-95 duration-700 delay-300">
+            <div className="flex items-center gap-4 mb-6 border-b border-emerald-100 pb-6">
+              <div className="w-14 h-14 bg-emerald-100 rounded-3xl flex items-center justify-center text-emerald-500">
+                <MessageCircle size={28} />
+              </div>
+              <div>
+                <h4 className="text-lg font-bold text-emerald-900">
+                  당신의 고민에 파도가 대답합니다
+                </h4>
+                <p className="text-sm text-emerald-700">
+                  낯선 이의 따뜻한 위로를 확인해 보세요.
+                </p>
+              </div>
+            </div>
+            <div className="text-slate-700 text-lg leading-relaxed font-serif italic whitespace-pre-wrap pl-4 border-l-2 border-emerald-200">
+              {letter.replyContent}
+            </div>
+            {letter.replyDate && (
+              <p className="text-xs text-emerald-400 mt-6 text-right font-mono">
+                Reply at: {new Date(letter.replyDate).toLocaleDateString()}
+              </p>
+            )}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/front/src/app/letters/mailbox/sent/page.tsx
+++ b/front/src/app/letters/mailbox/sent/page.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Send,
+  ChevronLeft,
+  Calendar,
+  MessageCircle,
+  Waves,
+} from "lucide-react";
+import { requestData } from "@/lib/api/http-client";
+
+interface SentLetter {
+  id: number;
+  title: string;
+  content: string;
+  status: string;
+  createdDate: string;
+}
+
+export default function SentLettersPage() {
+  const router = useRouter();
+  const [letters, setLetters] = useState<SentLetter[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchSentLetters = async () => {
+      try {
+        // response는 { letters: [...], totalElements: 2, ... } 형태입니다.
+        const response = await requestData<any>("/api/v1/letters/sent");
+
+        console.log("받은 데이터:", response);
+
+        // response 자체가 배열인지, 아니면 안에 letters라는 배열이 있는지 확인
+        if (response && Array.isArray(response.letters)) {
+          setLetters(response.letters); // 이 줄이 핵심!
+        } else if (Array.isArray(response)) {
+          setLetters(response);
+        } else {
+          setLetters([]);
+        }
+      } catch (error) {
+        console.error("편지 목록을 가져오는데 실패했습니다.", error);
+        setLetters([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchSentLetters();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#EBF5FF] text-slate-800 font-sans pb-20 selection:bg-sky-200">
+      {/* 상단 네비게이션 */}
+      <header className="p-6 flex items-center justify-between max-w-6xl mx-auto w-full">
+        <button
+          onClick={() => router.back()}
+          className="p-2 hover:bg-white/50 rounded-full transition-all text-slate-500 active:scale-90"
+        >
+          <ChevronLeft size={28} />
+        </button>
+        <h1 className="text-xl font-bold text-sky-900 flex items-center gap-2">
+          <Send size={20} className="text-sky-400" />
+          보낸 편지함
+        </h1>
+        <div className="w-10" />
+      </header>
+
+      <main className="max-w-6xl mx-auto px-6 mt-8">
+        {/* 요약 카드 */}
+        <section className="bg-white/60 backdrop-blur-md rounded-[2.5rem] p-8 mb-12 flex flex-col md:flex-row items-center justify-between border border-white/40 shadow-sm">
+          <div>
+            <h2 className="text-2xl font-bold text-slate-800 mb-2">
+              나의 진심이 {Array.isArray(letters) ? letters.length : 0}번
+              전달되었어요
+            </h2>
+            <p className="text-slate-500">
+              당신이 띄워 보낸 편지들이 누군가의 하루를 따뜻하게 만들고
+              있습니다.
+            </p>
+          </div>
+          <div className="mt-6 md:mt-0 p-4 bg-sky-400 text-white rounded-2xl shadow-lg shadow-sky-200 animate-bounce-slow">
+            <Waves size={32} />
+          </div>
+        </section>
+
+        {/* 편지 리스트 그리드 */}
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-4">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-sky-400"></div>
+            <p className="text-sky-600 font-medium">
+              바다 속 편지를 찾는 중...
+            </p>
+          </div>
+        ) : Array.isArray(letters) && letters.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {letters.map((letter) => (
+              <div
+                key={letter.id}
+                onClick={() =>
+                  router.push(`/letters/mailbox/sent/${letter.id}`)
+                }
+                className="group relative bg-white/80 hover:bg-white backdrop-blur-sm p-8 rounded-[2.5rem] shadow-[0_10px_30px_-10px_rgba(0,0,0,0.05)] border border-white transition-all duration-300 cursor-pointer hover:-translate-y-2 hover:shadow-xl"
+              >
+                {/* 편지 상단 장식 */}
+                <div className="flex justify-between items-start mb-6">
+                  <div className="flex items-center gap-2 text-[10px] font-bold text-sky-500 bg-sky-50 px-3 py-1 rounded-full uppercase tracking-wider">
+                    <Calendar size={12} />
+                    {letter.createdDate
+                      ? new Date(letter.createdDate).toLocaleDateString()
+                      : "날짜 정보 없음"}
+                  </div>
+                  {letter.status === "REPLIED" && (
+                    <div className="flex items-center gap-1 text-[10px] font-bold text-emerald-500 bg-emerald-50 px-3 py-1 rounded-full uppercase tracking-wider animate-pulse">
+                      <MessageCircle size={12} />
+                      답장 도착
+                    </div>
+                  )}
+                </div>
+
+                {/* 편지 제목 및 본문 미리보기 */}
+                <h3 className="text-xl font-bold text-slate-800 mb-3 line-clamp-1 group-hover:text-sky-600 transition-colors">
+                  {letter.title || "제목 없는 편지"}
+                </h3>
+                <p className="text-slate-500 text-sm leading-relaxed line-clamp-3 font-serif italic">
+                  {letter.content}
+                </p>
+
+                {/* 하단 장식선 */}
+                <div className="mt-8 pt-6 border-t border-slate-50 flex justify-between items-center">
+                  <span className="text-xs text-slate-300 font-serif italic">
+                    To. 바다 건너 누군가
+                  </span>
+                  <div className="w-8 h-8 rounded-full bg-sky-50 flex items-center justify-center text-sky-400 group-hover:bg-sky-400 group-hover:text-white transition-all">
+                    <Waves size={16} />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-24 bg-white/30 rounded-[3rem] border-2 border-dashed border-sky-100 flex flex-col items-center">
+            <div className="w-20 h-20 bg-sky-50 rounded-full flex items-center justify-center text-sky-200 mb-6">
+              <Send size={40} />
+            </div>
+            <p className="text-slate-400 text-lg mb-6">
+              아직 바다로 보낸 진심이 없네요.
+            </p>
+            <button
+              onClick={() => router.push("/letters/write")}
+              className="px-8 py-3 bg-white text-sky-500 font-bold rounded-full shadow-md hover:shadow-lg hover:bg-sky-500 hover:text-white transition-all active:scale-95"
+            >
+              첫 편지 작성하기
+            </button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/front/src/app/letters/write/page.tsx
+++ b/front/src/app/letters/write/page.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import React, { useState } from "react";
+import Image from "next/image";
+import { motion, AnimatePresence } from "framer-motion"; // AnimatePresence 추가
+import {
+  History,
+  Settings,
+  Bold,
+  Italic,
+  Eraser,
+  Waves,
+  Wind,
+} from "lucide-react";
+import { requestData } from "@/lib/api/http-client";
+import { useRouter } from "next/navigation";
+
+// --- 1. 애니메이션 컴포넌트 추가 ---
+function SendingAnimation() {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-[100] bg-sky-100 flex flex-col items-center justify-center overflow-hidden"
+    >
+      <motion.div
+        animate={{ x: [-20, 20, -20] }}
+        transition={{ repeat: Infinity, duration: 5, ease: "easeInOut" }}
+        className="absolute bottom-0 left-0 right-0 text-sky-200/50"
+      >
+        <Waves size={1200} strokeWidth={1} />
+      </motion.div>
+
+      <div className="relative flex flex-col items-center">
+        <motion.div
+          animate={{
+            y: [0, -15, 0],
+            rotate: [0, 5, -5, 0],
+            x: [0, 100, 400, 1200], // 오른쪽 멀리 사라짐
+          }}
+          transition={{
+            y: { repeat: Infinity, duration: 2, ease: "easeInOut" },
+            x: { duration: 4, ease: "easeIn" },
+          }}
+          className="relative z-10"
+        >
+          <div className="relative w-24 h-36 bg-white/30 backdrop-blur-md rounded-b-full rounded-t-3xl border-2 border-white/50 flex flex-col items-center justify-center shadow-2xl">
+            <div className="absolute -top-4 w-8 h-6 bg-white/40 border-2 border-white/50 rounded-t-lg" />
+            <div className="w-10 h-14 bg-amber-50 rounded-sm border border-amber-200 shadow-sm flex flex-col gap-1 p-1.5">
+              <div className="w-full h-1 bg-amber-200" />
+              <div className="w-4/5 h-1 bg-amber-200" />
+              <div className="w-full h-1 bg-amber-200" />
+            </div>
+          </div>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-12 text-center"
+        >
+          <h3 className="text-2xl font-bold text-sky-900 mb-2">
+            마음을 담아 보내는 중...
+          </h3>
+          <p className="text-sky-600 font-medium">
+            당신의 걱정은 파도가 가져갈 거예요.
+          </p>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}
+
+export default function WriteLetterPage() {
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [isSending, setIsSending] = useState(false);
+
+  const today = new Date()
+    .toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replace(/\.$/, "");
+
+  const handleSend = async () => {
+    if (!title.trim() || !content.trim()) {
+      alert("제목과 내용을 모두 채워주세요.");
+      return;
+    }
+
+    setIsSending(true); // 애니메이션 시작!
+
+    try {
+      // 1. API 전송
+      await requestData("/api/v1/letters", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: title,
+          content: content,
+        }),
+      });
+
+      // 2. 애니메이션이 충분히 보일 수 있도록 3.5초 정도 대기 후 이동
+      setTimeout(() => {
+        router.push("/letters/mailbox"); // 편지함 목록으로 이동
+      }, 4000);
+    } catch (error: any) {
+      setIsSending(false); // 에러 발생 시 애니메이션 중단
+      alert(error.message || "편지를 보내지 못했습니다.");
+    }
+  };
+
+  const handleReset = () => {
+    if (confirm("작성 중인 내용을 모두 지울까요?")) {
+      setTitle("");
+      setContent("");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-sky-50 text-sky-900 flex flex-col font-sans selection:bg-sky-200 relative">
+      {/* --- 애니메이션 오버레이 --- */}
+      <AnimatePresence>
+        {isSending && <SendingAnimation key="sending" />}
+      </AnimatePresence>
+
+      {/* 1. Header */}
+      <header className="flex items-center justify-between p-6">
+        <div
+          className="flex items-center gap-2 cursor-pointer"
+          onClick={() => router.push("/")}
+        >
+          {/* 이미지는 /public/logo.png가 있어야 나옵니다 */}
+          <div className="w-8 h-8 bg-sky-400 rounded-lg flex items-center justify-center text-white">
+            <Waves size={20} />
+          </div>
+          <h1 className="text-2xl font-bold tracking-tight">마음온</h1>
+        </div>
+        <div className="flex items-center gap-5 text-sky-700/70">
+          <button className="hover:text-sky-900 transition-colors">
+            <History size={24} />
+          </button>
+          <button className="hover:text-sky-900 transition-colors">
+            <Settings size={24} />
+          </button>
+        </div>
+      </header>
+
+      {/* 2. Main Content */}
+      <main className="flex-grow flex flex-col items-center justify-center px-4 py-10">
+        <section className="text-center mb-10">
+          <h2 className="text-4xl font-bold text-slate-800 mb-3">
+            걱정을 놓아주세요
+          </h2>
+          <p className="text-slate-600 text-lg">
+            무거운 마음을 양피지에 적어보세요.
+            <br />
+            준비가 되면, 파도가 당신의 고민을 영원히 가져가게 두세요.
+          </p>
+        </section>
+
+        {/* 3. Letter Card */}
+        <div className="relative w-full max-w-2xl bg-white/80 backdrop-blur-md rounded-[2.5rem] p-8 md:p-12 shadow-[0_30px_60px_-15px_rgba(186,215,233,0.5)] border border-white/40">
+          <div className="absolute top-[-10px] left-1/2 -translate-x-1/2 w-12 h-6 bg-[#C6A487] rounded-full shadow-md z-10"></div>
+
+          <div className="flex flex-col gap-4 mb-6 border-b border-slate-100 pb-6">
+            <div className="flex justify-between items-center text-slate-400 text-sm font-medium italic">
+              <span>바다에게 보내는 편지...</span>
+              <span>{today}</span>
+            </div>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="제목을 입력하세요"
+              className="w-full bg-transparent border-none focus:ring-0 text-2xl font-bold text-slate-800 placeholder:text-slate-200 p-0"
+            />
+          </div>
+
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="여기에 당신의 고민을 솔직하게 담아주세요..."
+            className="w-full h-[350px] bg-transparent text-slate-700 text-lg leading-relaxed resize-none border-none focus:ring-0 placeholder:text-slate-200 font-serif"
+          />
+
+          <div className="flex justify-between items-center mt-4 pt-4 border-t border-slate-50 text-slate-300">
+            <div className="flex items-center gap-5">
+              <Bold size={20} className="hover:text-slate-500 cursor-pointer" />
+              <Italic
+                size={20}
+                className="hover:text-slate-500 cursor-pointer"
+              />
+            </div>
+            <button
+              onClick={handleReset}
+              className="hover:text-rose-400 transition-colors"
+            >
+              <Eraser size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* 5. Send Button */}
+        <button
+          onClick={handleSend}
+          disabled={isSending}
+          className={`mt-12 flex items-center gap-3 px-12 py-5 rounded-full text-xl font-bold shadow-lg transition-all transform hover:-translate-y-1 active:scale-95 ${
+            isSending
+              ? "bg-slate-300 cursor-not-allowed opacity-50"
+              : "bg-sky-400 text-white hover:bg-sky-500 shadow-sky-200"
+          }`}
+        >
+          {isSending ? (
+            <span className="animate-pulse">편지를 띄우는 중...</span>
+          ) : (
+            <>
+              <Waves size={24} />
+              병을 담아 바다로 보내기
+            </>
+          )}
+        </button>
+      </main>
+
+      {/* ... Footer 생략 (동일) ... */}
+    </div>
+  );
+}

--- a/front/src/components/letters/SendingAnimation.tsx
+++ b/front/src/components/letters/SendingAnimation.tsx
@@ -1,0 +1,89 @@
+// components/letters/SendingAnimation.tsx
+"use client";
+
+import React from "react";
+import { motion } from "framer-motion";
+import { Waves, Ship, Wind } from "lucide-react";
+
+export default function SendingAnimation() {
+  return (
+    <div className="fixed inset-0 z-[100] bg-sky-100 flex flex-col items-center justify-center overflow-hidden">
+      {/* 배경 파도 애니메이션 */}
+      <motion.div
+        animate={{
+          x: [-20, 20, -20],
+        }}
+        transition={{ repeat: Infinity, duration: 5, ease: "easeInOut" }}
+        className="absolute bottom-0 left-0 right-0 text-sky-200/50"
+      >
+        <Waves size={1200} strokeWidth={1} />
+      </motion.div>
+
+      <div className="relative flex flex-col items-center">
+        {/* 유리병 & 편지 애니메이션 */}
+        <motion.div
+          initial={{ y: 100, opacity: 0, rotate: -20 }}
+          animate={{
+            y: [0, -15, 0],
+            opacity: 1,
+            rotate: [0, 5, -5, 0],
+            x: [0, 100, 300, 600], // 오른쪽 멀리 떠나감
+          }}
+          transition={{
+            y: { repeat: Infinity, duration: 2, ease: "easeInOut" },
+            x: { duration: 4, ease: "easeIn" },
+            opacity: { duration: 0.5 },
+          }}
+          className="relative z-10"
+        >
+          {/* 유리병 모양 커스텀 UI (아이콘 조합) */}
+          <div className="relative w-24 h-40 bg-white/30 backdrop-blur-sm rounded-b-full rounded-t-3xl border-2 border-white/50 flex flex-col items-center justify-center shadow-xl">
+            {/* 병 주둥이 */}
+            <div className="absolute -top-4 w-8 h-6 bg-white/40 border-2 border-white/50 rounded-t-lg" />
+            {/* 내부 편지지 */}
+            <motion.div
+              initial={{ scale: 0.5 }}
+              animate={{ scale: 1 }}
+              className="w-12 h-16 bg-amber-50 rounded-sm border border-amber-200 shadow-sm flex flex-col gap-1 p-2"
+            >
+              <div className="w-full h-1 bg-amber-200" />
+              <div className="w-4/5 h-1 bg-amber-200" />
+              <div className="w-full h-1 bg-amber-200" />
+            </motion.div>
+          </div>
+
+          {/* 물보라 효과 */}
+          <motion.div
+            animate={{ scale: [1, 1.5], opacity: [0.5, 0] }}
+            transition={{ repeat: Infinity, duration: 1 }}
+            className="absolute -bottom-4 left-1/2 -translate-x-1/2 w-20 h-8 bg-white/40 rounded-full blur-xl"
+          />
+        </motion.div>
+
+        {/* 텍스트 메시지 */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="mt-12 text-center"
+        >
+          <h3 className="text-2xl font-bold text-sky-900 mb-2">
+            마음을 병에 담는 중...
+          </h3>
+          <p className="text-sky-600 font-medium italic">
+            당신의 진심이 곧 바다 건너 누군가에게 닿을 거예요.
+          </p>
+        </motion.div>
+      </div>
+
+      {/* 지나가는 구름 애니메이션 */}
+      <motion.div
+        animate={{ x: [-100, 1500] }}
+        transition={{ duration: 20, repeat: Infinity, ease: "linear" }}
+        className="absolute top-20 left-0 text-white opacity-40"
+      >
+        <Wind size={60} />
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 Issue 번호
- close #34 

## 🛠 작업 내역
- Back : 일기 작성/조회 API 개발: JWT 인증 기반(AuthenticatedMember)의 일기 CRUD 구
- Front : 편지 작성 / 받은 편지, 보낸 편지 조회 / 편지 전송 애니메이션 구현

## 🔄 변경 사항
-

## ✨ 새로운 기능
-일기 작성 (POST /api/v1/diaries): 제목, 내용, 카테고리를 입력받아 본인의 비밀 서랍에 저장

-일기 상세 조회 (GET /api/v1/diaries/{id}): 특정 일기의 상세 내용을 조회 (본인 확인 로직 포함)

-일기 목록 조회 (GET /api/v1/diaries): 본인이 작성한 일기 전체 목록을 최신순으로 조회

-일기 삭제 (GET /api/v1/diaries/{id}) : 작성한 일기 삭제

-일기 조회 (GET /api/v1/diaries/{id}) : 작성한 일기 수정

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

