### PR TITLE
Feat:#50 Diary 이미지 업로드 구현(로컬 저장소)

### DIFF
--- a/back/src/main/java/com/back/diary/controller/DiaryController.java
+++ b/back/src/main/java/com/back/diary/controller/DiaryController.java
@@ -7,8 +7,14 @@ import com.back.global.rsData.RsData;
 import com.back.global.security.adapter.in.AuthenticatedMember;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -19,20 +25,38 @@ public class DiaryController {
 
     private final DiaryService diaryService;
 
+
+    //일기 작성
     @PostMapping
     public RsData<Long> create(
-            @Valid @RequestBody DiaryCreateReq req,
+            @Valid @RequestPart("data") DiaryCreateReq req,
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
         Long diaryId = diaryService.write(
                 req,
+                image,
                 authenticatedMember.memberId()
         );
 
         return new RsData<>("201-1", "일기가 저장되었습니다.", diaryId);
     }
 
+    //공개 허용된 일기 목록 조회
+    @GetMapping("/public")
+    public RsData<Page<DiaryRes>> getPublicList(
+            @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<DiaryRes> publicDiaries = diaryService.getPublicDiaries(pageable);
 
+        if (publicDiaries.isEmpty()) {
+            return new RsData<>("204-1", "공개된 일기가 없습니다.", Page.empty());
+        }
+
+        return new RsData<>("200-3", "공개 일기 목록을 가져왔습니다.", publicDiaries);
+    }
+
+    //일기 단건 조회
     @GetMapping("/{id}")
     public RsData<DiaryRes> getOne(
             @PathVariable Long id,
@@ -43,26 +67,32 @@ public class DiaryController {
         return new RsData<>("200-1", "일기를 불러왔습니다.", diaryRes);
     }
 
+    //내 일기 목록 조회
     @GetMapping
-    public RsData<List<DiaryRes>> getMyList(
-            @AuthenticationPrincipal AuthenticatedMember authenticatedMember
+    public RsData<Page<DiaryRes>> getMyList(
+            @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
+            @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<DiaryRes> myDiaries = diaryService.getMyDiaries(authenticatedMember.memberId());
+        Page<DiaryRes> myDiaries = diaryService.getMyDiaries(authenticatedMember.memberId(), pageable);
 
-        return new RsData<>("200-2", "일기들을 가져왔습니다.", myDiaries);
+        return new RsData<>("200-2", "일기 목록을 가져왔습니다.", myDiaries);
     }
 
 
-    @PutMapping("/{id}")
+
+    //일기 수정
+    @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<Void> modify(
             @PathVariable Long id,
-            @Valid @RequestBody DiaryCreateReq req,
+            @Valid @RequestPart("data") DiaryCreateReq req, // @RequestBody -> @RequestPart로 변경
+            @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        diaryService.modify(id, req, authenticatedMember.memberId());
+        diaryService.modify(id, req, image, authenticatedMember.memberId());
         return new RsData<>("200-1", "%d번 일기가 수정되었습니다.".formatted(id));
     }
 
+    //일기 삭제
     @DeleteMapping("/{id}")
     public RsData<Void> delete(
             @PathVariable Long id,

--- a/back/src/main/java/com/back/diary/dto/DiaryCreateReq.java
+++ b/back/src/main/java/com/back/diary/dto/DiaryCreateReq.java
@@ -11,7 +11,8 @@ public record DiaryCreateReq(
     String content,
     
     @NotBlank(message = "카테고리를 선택해주세요.")
-    String categoryName
+    String categoryName,
+    boolean isPrivate
 ) {
     // Service 계층에서 엔티티로 변환할 때 사용
     public Diary toEntity(Long memberId, String nickname) {

--- a/back/src/main/java/com/back/diary/entity/Diary.java
+++ b/back/src/main/java/com/back/diary/entity/Diary.java
@@ -30,22 +30,32 @@ public class Diary extends BaseEntity {
     @Column(nullable = false)
     private String categoryName;
 
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+
     @Column(nullable = false)
     private boolean isPrivate = true;
 
-    public void modify(String title, String content, String categoryName) {
-        this.title = title;
-        this.content = content;
-        this.categoryName = categoryName;
-    }
-
     @Builder
-    public Diary(Long memberId, String nickname, String title, String content, String categoryName) {
+    public Diary(Long memberId, String nickname, String title, String content, String categoryName, String imageUrl, boolean isPrivate) {
         this.memberId = memberId;
         this.nickname = (nickname == null) ? "익명" : nickname;
-        this.nickname = nickname;
         this.title = title;
         this.content = content;
         this.categoryName = categoryName;
+        this.imageUrl = imageUrl;
+        this.isPrivate = isPrivate;
     }
+
+    public void modify(String title, String content, String categoryName, String imageUrl, boolean isPrivate) {
+        this.title = title;
+        this.content = content;
+        this.categoryName = categoryName;
+        if (imageUrl != null) {
+            this.imageUrl = imageUrl;
+        }
+        this.isPrivate = isPrivate;
+    }
+
+
 }

--- a/back/src/main/java/com/back/diary/repository/DiaryRepository.java
+++ b/back/src/main/java/com/back/diary/repository/DiaryRepository.java
@@ -1,11 +1,17 @@
 package com.back.diary.repository;
 
 import com.back.diary.entity.Diary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    List<Diary> findAllByMemberIdOrderByCreateDateDesc(Long memberId);
+    // 본인 일기 페이징 조회
+    Page<Diary> findAllByMemberIdOrderByCreateDateDesc(Long memberId, Pageable pageable);
+
+    // 공개된 타인 일기 페이징 조회 (선택 사항)
+    Page<Diary> findAllByIsPrivateFalseOrderByCreateDateDesc(Pageable pageable);
 
 }

--- a/back/src/main/java/com/back/diary/service/DiaryService.java
+++ b/back/src/main/java/com/back/diary/service/DiaryService.java
@@ -8,8 +8,11 @@ import com.back.global.exception.ServiceException;
 import com.back.member.domain.Member;
 import com.back.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -20,14 +23,21 @@ public class DiaryService {
 
     private final DiaryRepository diaryRepository;
     private final MemberRepository memberRepository;
+    private final ImageService imageService;
 
     @Transactional
-    public Long write(DiaryCreateReq req, Long memberId) {
+    public Long write(DiaryCreateReq req, MultipartFile image, Long memberId) {
+        String imageUrl = imageService.upload(image);
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ServiceException("404-1", "사용자를 찾을 수 없습니다."));
-
-        Diary diary = req.toEntity(memberId, member.getNickname());
+        Diary diary = Diary.builder()
+                .memberId(memberId)
+                .nickname("익명")
+                .title(req.title())
+                .content(req.content())
+                .categoryName(req.categoryName())
+                .imageUrl(imageUrl)
+                .isPrivate(req.isPrivate())
+                .build();
 
         return diaryRepository.save(diary).getId();
     }
@@ -37,23 +47,30 @@ public class DiaryService {
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
-        if (!diary.getMemberId().equals(currentMemberId)) {
-            // 보안상 403 대신 404를 던져 해당 리소스의 존재 유무를 숨길 수 있습니다.
-            throw new ServiceException("404-1", "존재하지 않는 일기입니다.");
+        if (diary.isPrivate()) { // 비공개 일기인 경우
+            if (currentMemberId == null || !diary.getMemberId().equals(currentMemberId)) {
+                throw new ServiceException("403-1", "비공개 일기입니다. 접근 권한이 없습니다.");
+            }
         }
 
         return DiaryRes.from(diary);
     }
 
-    public List<DiaryRes> getMyDiaries(Long memberId) {
-        return diaryRepository.findAllByMemberIdOrderByCreateDateDesc(memberId)
-                .stream()
-                .map(DiaryRes::from) // Entity -> DTO 변환
-                .toList();
+    //내 일기 조회
+    public Page<DiaryRes> getMyDiaries(Long memberId, Pageable pageable) {
+        return diaryRepository.findAllByMemberIdOrderByCreateDateDesc(memberId, pageable)
+                .map(DiaryRes::from);
+    }
+
+    //공개 허용 일기 목록 조회
+    public Page<DiaryRes> getPublicDiaries(Pageable pageable) {
+        return diaryRepository.findAllByIsPrivateFalseOrderByCreateDateDesc(pageable)
+                .map(DiaryRes::from);
     }
 
     @Transactional
-    public void modify(Long diaryId, DiaryCreateReq req, Long currentMemberId) {
+    public void modify(Long diaryId, DiaryCreateReq req, MultipartFile image, Long currentMemberId) {
+
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
@@ -61,7 +78,22 @@ public class DiaryService {
             throw new ServiceException("403-1", "수정 권한이 없습니다.");
         }
 
-        diary.modify(req.title(), req.content(), req.categoryName());
+        String newImageUrl = diary.getImageUrl();
+
+        if (image != null && !image.isEmpty()) {
+            if (diary.getImageUrl() != null) {
+                imageService.delete(diary.getImageUrl());
+            }
+            newImageUrl = imageService.upload(image);
+        }
+
+        diary.modify(
+                req.title(),
+                req.content(),
+                req.categoryName(),
+                newImageUrl,
+                req.isPrivate()
+        );
     }
 
     @Transactional

--- a/back/src/main/java/com/back/diary/service/ImageService.java
+++ b/back/src/main/java/com/back/diary/service/ImageService.java
@@ -1,0 +1,8 @@
+package com.back.diary.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    String upload(MultipartFile file);
+    void delete(String fileUrl);
+}

--- a/back/src/main/java/com/back/diary/service/LocalImageService.java
+++ b/back/src/main/java/com/back/diary/service/LocalImageService.java
@@ -1,0 +1,54 @@
+package com.back.diary.service;
+
+import com.back.global.exception.ServiceException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Service
+@Primary // 우선 로컬 서비스를 사용하도록 설정
+public class LocalImageService implements ImageService {
+
+    // application.yml에 설정한 저장 경로
+    @Value("${custom.file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public String upload(MultipartFile file) {
+        if (file == null || file.isEmpty()) return null;
+
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Path filePath = Paths.get(uploadDir, fileName);
+
+        try {
+            // 폴더가 없으면 생성
+            Files.createDirectories(filePath.getParent());
+            // 파일 저장
+            Files.write(filePath, file.getBytes());
+        } catch (IOException e) {
+            throw new ServiceException("500-1", "로컬 파일 저장 중 오류가 발생했습니다.");
+        }
+
+        // 브라우저에서 접근 가능한 URL 경로 반환 (예: /gen/2026/03/uuid_test.png)
+        return "/gen/" + fileName;
+    }
+
+    @Override
+    public void delete(String fileUrl) {
+        if (fileUrl == null) return;
+        String fileName = fileUrl.replace("/gen/", "");
+        try {
+            Files.deleteIfExists(Paths.get(uploadDir, fileName));
+        } catch (IOException e) {
+            // 삭제 실패는 로그만 남기고 진행
+            System.err.println("파일 삭제 실패: " + e.getMessage());
+        }
+    }
+}

--- a/back/src/main/java/com/back/global/config/WebConfig.java
+++ b/back/src/main/java/com/back/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.back.global.config;
+
+import com.google.api.client.util.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${custom.file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        // /gen/** 로 시작하는 요청이 오면 실제 로컬 폴더에서 파일을 찾음
+        registry.addResourceHandler("/gen/**")
+                .addResourceLocations("file:///" + uploadDir + "/");
+    }
+}

--- a/back/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -101,6 +101,7 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/members", "/api/v1/auth/**")
                     .permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/diaries/public").permitAll()
                     // 관리자 경로는 ADMIN 권한이 필요하다.
                     .requestMatchers("/api/v1/admin/**")
                     .hasRole("ADMIN")

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -35,7 +35,10 @@ spring:
             scope:
               - openid
               - profile_nickname
-
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 custom:
   auth:
     oidc:
@@ -52,3 +55,6 @@ custom:
     refresh-token-cookie-name: ${JWT_REFRESH_TOKEN_COOKIE_NAME:refreshToken}
     refresh-token-cookie-secure: ${JWT_REFRESH_TOKEN_COOKIE_SECURE:false}
     refresh-token-cookie-same-site: ${JWT_REFRESH_TOKEN_COOKIE_SAME_SITE:Lax}
+  file:
+    upload-dir: C:/javadev/diary_image
+


### PR DESCRIPTION
## 🔗 Issue 번호
- close #50 

## 🛠 작업 내역
-공개/비공개 권한 로직: 일기별 isPrivate 상태에 따른 접근 제어 로직 구현 (단건 조회 시 권한 체크 포함)
-임시 이미지 업로드 구현: AWS S3 도입 전 단계로, 로컬 파일 시스템을 활용한 이미지 저장 로직을 구현하였습니다.
-일기 공개 여부 설정: isPrivate 필드를 도입하여 사용자가 일기 작성 및 수정 시 공개/비공개 상태를 직접 선택할 수 있도록 기능을 추가하였습니다.
## 🔄 변경 사항
-설정 파일(application.yml) 수정 권고:

로컬 저장 경로가 C:/javadev/diary_image로 설정되어 있습니다.

원활한 테스트를 위해 본인의 로컬 환경에 맞는 폴더 경로로 file.upload-dir 값을 수정하여 사용하시길 권장합니다.

## ✨ 새로운 기능
OST /api/v1/diaries: 일기 작성 시 이미지 첨부 및 공개 여부(isPrivate) 설정 가능
<img width="693" height="834" alt="image" src="https://github.com/user-attachments/assets/4fd869a3-c4a3-460d-86b1-9d25b46cab2c" />

POSTMAN으로 테스트시 Body를 form-data 타입으로 변환 후 Key : image Type : File Value : 이미지 선택
Key : data Type : Text
<img width="270" height="167" alt="image" src="https://github.com/user-attachments/assets/8cff24cc-4662-4137-befe-4dfb4f1cc469" />
첨부 사진 참고하여 Content-Type 선택해 활성화 후 application/json 삽입 후 
Value : {
  "title": "테스트 제목",
  "content": "테스트 내용입니다.",
  "categoryName": "일상" ,
  "isPrivate": true
}
"isPrivate" : true (비공개)
"isPrivate" : false (공개)


GET /api/v1/diaries/public: 페이징 처리가 적용된 공개 일기 목록 최신순 조회

PUT /api/v1/diaries/{id}: 기존 일기의 내용, 이미지, 공개 상태 수정 가능

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

