### PR TITLE
Refactor:#52 Diary 도메인 헥사고날 아키텍처로 전환

### DIFF
--- a/back/src/main/java/com/back/diary/adapter/application/port/in/DiaryUseCase.java
+++ b/back/src/main/java/com/back/diary/adapter/application/port/in/DiaryUseCase.java
@@ -1,0 +1,16 @@
+package com.back.diary.adapter.application.port.in;// package com.back.diary.adapter.application.port.in;
+
+import com.back.diary.adapter.application.port.in.dto.DiaryCreateReq;
+import com.back.diary.adapter.application.port.in.dto.DiaryRes;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface DiaryUseCase {
+    Long write(DiaryCreateReq req, MultipartFile image, Long memberId);
+    DiaryRes getDiary(Long diaryId, Long currentMemberId);
+    Page<DiaryRes> getMyDiaries(Long memberId, Pageable pageable);
+    Page<DiaryRes> getPublicDiaries(Pageable pageable);
+    void modify(Long diaryId, DiaryCreateReq req, MultipartFile image, Long currentMemberId);
+    void delete(Long diaryId, Long currentMemberId);
+}

--- a/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryCreateReq.java
+++ b/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryCreateReq.java
@@ -1,6 +1,6 @@
-package com.back.diary.dto;
+package com.back.diary.adapter.application.port.in.dto;
 
-import com.back.diary.entity.Diary;
+import com.back.diary.domain.Diary;
 import jakarta.validation.constraints.NotBlank;
 
 public record DiaryCreateReq(

--- a/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryListRes.java
+++ b/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryListRes.java
@@ -1,6 +1,6 @@
-package com.back.diary.dto;
+package com.back.diary.adapter.application.port.in.dto;
 
-import com.back.diary.entity.Diary;
+import com.back.diary.domain.Diary;
 
 import java.time.LocalDateTime;
 

--- a/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryRes.java
+++ b/back/src/main/java/com/back/diary/adapter/application/port/in/dto/DiaryRes.java
@@ -1,6 +1,6 @@
-package com.back.diary.dto;
+package com.back.diary.adapter.application.port.in.dto;
 
-import com.back.diary.entity.Diary;
+import com.back.diary.domain.Diary;
 
 import java.time.LocalDateTime;
 

--- a/back/src/main/java/com/back/diary/adapter/application/port/out/DiaryPort.java
+++ b/back/src/main/java/com/back/diary/adapter/application/port/out/DiaryPort.java
@@ -1,0 +1,16 @@
+package com.back.diary.adapter.application.port.out;
+
+import com.back.diary.domain.Diary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+// 위치: com.back.diary.adapter.application.port.out
+public interface DiaryPort {
+    Diary save(Diary diary);
+    Optional<Diary> findById(Long id);
+    Page<Diary> findAllByMemberId(Long memberId, Pageable pageable);
+    Page<Diary> findAllPublic(Pageable pageable);
+    void delete(Diary diary);
+}

--- a/back/src/main/java/com/back/diary/adapter/application/service/DiaryService.java
+++ b/back/src/main/java/com/back/diary/adapter/application/service/DiaryService.java
@@ -1,12 +1,11 @@
-package com.back.diary.service;
+package com.back.diary.adapter.application.service;
 
-import com.back.diary.dto.DiaryCreateReq;
-import com.back.diary.dto.DiaryRes;
-import com.back.diary.entity.Diary;
-import com.back.diary.repository.DiaryRepository;
+import com.back.diary.adapter.application.port.in.DiaryUseCase;
+import com.back.diary.adapter.application.port.in.dto.DiaryCreateReq;
+import com.back.diary.adapter.application.port.in.dto.DiaryRes;
+import com.back.diary.adapter.application.port.out.DiaryPort;
+import com.back.diary.domain.Diary;
 import com.back.global.exception.ServiceException;
-import com.back.member.domain.Member;
-import com.back.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,17 +13,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class DiaryService {
+public class DiaryService implements DiaryUseCase { // 1. Inbound Port 구현
 
-    private final DiaryRepository diaryRepository;
-    private final MemberRepository memberRepository;
+    // 2. 외부 어댑터(JPA)가 아닌 포트(인터페이스)에 의존
+    private final DiaryPort diaryRepositoryPort;
     private final ImageService imageService;
 
+    @Override
     @Transactional
     public Long write(DiaryCreateReq req, MultipartFile image, Long memberId) {
         String imageUrl = imageService.upload(image);
@@ -39,15 +37,15 @@ public class DiaryService {
                 .isPrivate(req.isPrivate())
                 .build();
 
-        return diaryRepository.save(diary).getId();
+        return diaryRepositoryPort.save(diary).getId();
     }
 
-    /** 일기 단건 조회 (보안 체크 포함) */
+    @Override
     public DiaryRes getDiary(Long diaryId, Long currentMemberId) {
-        Diary diary = diaryRepository.findById(diaryId)
+        Diary diary = diaryRepositoryPort.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
-        if (diary.isPrivate()) { // 비공개 일기인 경우
+        if (diary.isPrivate()) {
             if (currentMemberId == null || !diary.getMemberId().equals(currentMemberId)) {
                 throw new ServiceException("403-1", "비공개 일기입니다. 접근 권한이 없습니다.");
             }
@@ -56,22 +54,22 @@ public class DiaryService {
         return DiaryRes.from(diary);
     }
 
-    //내 일기 조회
+    @Override
     public Page<DiaryRes> getMyDiaries(Long memberId, Pageable pageable) {
-        return diaryRepository.findAllByMemberIdOrderByCreateDateDesc(memberId, pageable)
+        return diaryRepositoryPort.findAllByMemberId(memberId, pageable)
                 .map(DiaryRes::from);
     }
 
-    //공개 허용 일기 목록 조회
+    @Override
     public Page<DiaryRes> getPublicDiaries(Pageable pageable) {
-        return diaryRepository.findAllByIsPrivateFalseOrderByCreateDateDesc(pageable)
+        return diaryRepositoryPort.findAllPublic(pageable)
                 .map(DiaryRes::from);
     }
 
+    @Override
     @Transactional
     public void modify(Long diaryId, DiaryCreateReq req, MultipartFile image, Long currentMemberId) {
-
-        Diary diary = diaryRepository.findById(diaryId)
+        Diary diary = diaryRepositoryPort.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
         if (!diary.getMemberId().equals(currentMemberId)) {
@@ -94,17 +92,19 @@ public class DiaryService {
                 newImageUrl,
                 req.isPrivate()
         );
+        diaryRepositoryPort.save(diary);
     }
 
+    @Override
     @Transactional
     public void delete(Long diaryId, Long currentMemberId) {
-        Diary diary = diaryRepository.findById(diaryId)
+        Diary diary = diaryRepositoryPort.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
         if (!diary.getMemberId().equals(currentMemberId)) {
             throw new ServiceException("403-1", "삭제 권한이 없습니다.");
         }
 
-        diaryRepository.delete(diary);
+        diaryRepositoryPort.delete(diary);
     }
 }

--- a/back/src/main/java/com/back/diary/adapter/application/service/ImageService.java
+++ b/back/src/main/java/com/back/diary/adapter/application/service/ImageService.java
@@ -1,4 +1,4 @@
-package com.back.diary.service;
+package com.back.diary.adapter.application.service;
 
 import org.springframework.web.multipart.MultipartFile;
 

--- a/back/src/main/java/com/back/diary/adapter/application/service/LocalImageService.java
+++ b/back/src/main/java/com/back/diary/adapter/application/service/LocalImageService.java
@@ -1,4 +1,4 @@
-package com.back.diary.service;
+package com.back.diary.adapter.application.service;
 
 import com.back.global.exception.ServiceException;
 import org.springframework.beans.factory.annotation.Value;

--- a/back/src/main/java/com/back/diary/adapter/in/web/DiaryController.java
+++ b/back/src/main/java/com/back/diary/adapter/in/web/DiaryController.java
@@ -1,8 +1,8 @@
-package com.back.diary.controller;
+package com.back.diary.adapter.in.web;
 
-import com.back.diary.dto.DiaryCreateReq;
-import com.back.diary.dto.DiaryRes;
-import com.back.diary.service.DiaryService;
+import com.back.diary.adapter.application.port.in.DiaryUseCase; // 인터페이스 임포트
+import com.back.diary.adapter.application.port.in.dto.DiaryCreateReq;
+import com.back.diary.adapter.application.port.in.dto.DiaryRes;
 import com.back.global.rsData.RsData;
 import com.back.global.security.adapter.in.AuthenticatedMember;
 import jakarta.validation.Valid;
@@ -16,24 +16,22 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/diaries")
 @RequiredArgsConstructor
 public class DiaryController {
 
-    private final DiaryService diaryService;
+    // 핵심: 구현체인 DiaryService 대신 인터페이스인 DiaryUseCase에 의존합니다.
+    private final DiaryUseCase diaryUseCase;
 
-
-    //일기 작성
-    @PostMapping
+    // 일기 작성
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<Long> create(
             @Valid @RequestPart("data") DiaryCreateReq req,
             @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        Long diaryId = diaryService.write(
+        Long diaryId = diaryUseCase.write(
                 req,
                 image,
                 authenticatedMember.memberId()
@@ -42,12 +40,12 @@ public class DiaryController {
         return new RsData<>("201-1", "일기가 저장되었습니다.", diaryId);
     }
 
-    //공개 허용된 일기 목록 조회
+    // 공개 허용된 일기 목록 조회
     @GetMapping("/public")
     public RsData<Page<DiaryRes>> getPublicList(
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<DiaryRes> publicDiaries = diaryService.getPublicDiaries(pageable);
+        Page<DiaryRes> publicDiaries = diaryUseCase.getPublicDiaries(pageable);
 
         if (publicDiaries.isEmpty()) {
             return new RsData<>("204-1", "공개된 일기가 없습니다.", Page.empty());
@@ -56,49 +54,47 @@ public class DiaryController {
         return new RsData<>("200-3", "공개 일기 목록을 가져왔습니다.", publicDiaries);
     }
 
-    //일기 단건 조회
+    // 일기 단건 조회
     @GetMapping("/{id}")
     public RsData<DiaryRes> getOne(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        DiaryRes diaryRes = diaryService.getDiary(id, authenticatedMember.memberId());
+        DiaryRes diaryRes = diaryUseCase.getDiary(id, authenticatedMember.memberId());
 
         return new RsData<>("200-1", "일기를 불러왔습니다.", diaryRes);
     }
 
-    //내 일기 목록 조회
+    // 내 일기 목록 조회
     @GetMapping
     public RsData<Page<DiaryRes>> getMyList(
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember,
             @PageableDefault(size = 10, sort = "createDate", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<DiaryRes> myDiaries = diaryService.getMyDiaries(authenticatedMember.memberId(), pageable);
+        Page<DiaryRes> myDiaries = diaryUseCase.getMyDiaries(authenticatedMember.memberId(), pageable);
 
         return new RsData<>("200-2", "일기 목록을 가져왔습니다.", myDiaries);
     }
 
-
-
-    //일기 수정
+    // 일기 수정
     @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public RsData<Void> modify(
             @PathVariable Long id,
-            @Valid @RequestPart("data") DiaryCreateReq req, // @RequestBody -> @RequestPart로 변경
+            @Valid @RequestPart("data") DiaryCreateReq req,
             @RequestPart(value = "image", required = false) MultipartFile image,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        diaryService.modify(id, req, image, authenticatedMember.memberId());
+        diaryUseCase.modify(id, req, image, authenticatedMember.memberId());
         return new RsData<>("200-1", "%d번 일기가 수정되었습니다.".formatted(id));
     }
 
-    //일기 삭제
+    // 일기 삭제
     @DeleteMapping("/{id}")
     public RsData<Void> delete(
             @PathVariable Long id,
             @AuthenticationPrincipal AuthenticatedMember authenticatedMember
     ) {
-        diaryService.delete(id, authenticatedMember.memberId());
+        diaryUseCase.delete(id, authenticatedMember.memberId());
         return new RsData<>("200-1", "%d번 일기가 삭제되었습니다.".formatted(id));
     }
 }

--- a/back/src/main/java/com/back/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
+++ b/back/src/main/java/com/back/diary/adapter/out/persistence/DiaryPersistenceAdapter.java
@@ -1,0 +1,43 @@
+package com.back.diary.adapter.out.persistence;
+
+import com.back.diary.adapter.application.port.out.DiaryPort;
+import com.back.diary.adapter.out.persistence.repository.DiaryRepository;
+import com.back.diary.domain.Diary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class DiaryPersistenceAdapter implements DiaryPort {
+
+    private final DiaryRepository diaryRepository;
+
+    @Override
+    public Diary save(Diary diary) {
+        return diaryRepository.save(diary);
+    }
+
+    @Override
+    public Optional<Diary> findById(Long id) {
+        return diaryRepository.findById(id);
+    }
+
+    @Override
+    public Page<Diary> findAllByMemberId(Long memberId, Pageable pageable) {
+        return diaryRepository.findAllByMemberIdOrderByCreateDateDesc(memberId, pageable);
+    }
+
+    @Override
+    public Page<Diary> findAllPublic(Pageable pageable) {
+        return diaryRepository.findAllByIsPrivateFalseOrderByCreateDateDesc(pageable);
+    }
+
+    @Override
+    public void delete(Diary diary) {
+        diaryRepository.delete(diary);
+    }
+}

--- a/back/src/main/java/com/back/diary/adapter/out/persistence/repository/DiaryRepository.java
+++ b/back/src/main/java/com/back/diary/adapter/out/persistence/repository/DiaryRepository.java
@@ -1,11 +1,9 @@
-package com.back.diary.repository;
+package com.back.diary.adapter.out.persistence.repository;
 
-import com.back.diary.entity.Diary;
+import com.back.diary.domain.Diary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     // 본인 일기 페이징 조회

--- a/back/src/main/java/com/back/diary/domain/Diary.java
+++ b/back/src/main/java/com/back/diary/domain/Diary.java
@@ -1,10 +1,8 @@
-package com.back.diary.entity;
+package com.back.diary.domain;
 
 import com.back.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;


### PR DESCRIPTION
## 🔗 Issue 번호
- close #52 

## 🛠 작업 내역
-아키텍처 구조 개편: 기존 계층형(Layered) 구조에서 헥사고날 아키텍처(Ports and Adapters)로 전환
-DiaryService가 인터페이스인 DiaryUseCase를 구현하고 DiaryPort에 의존하도록 수정.


## 🔄 변경 사항
-패키지 경로 이동: 도메인 엔티티, 포트, 서비스, 어댑터를 각각 헥사고날 레이어에 맞는 패키지로 재배치.

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

