### PR TITLE
[Refactor] 보호 페이지 인증을 클라이언트 -> 서버로 옮기기

### DIFF
--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -1,0 +1,135 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { AUTH_HINT_COOKIE_NAME } from "@/lib/auth/auth-hint-cookie";
+
+const BACKEND_BASE_URL =
+  process.env.BACKEND_INTERNAL_URL ??
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  "http://localhost:8080";
+const REFRESH_PATH = "/api/v1/auth/refresh";
+const REFRESH_COOKIE_NAME = "refreshToken";
+
+interface AuthMember {
+  role: string;
+}
+
+interface AuthRefreshData {
+  accessToken: string;
+  member: AuthMember;
+}
+
+interface RsData<T> {
+  resultCode: string;
+  msg: string;
+  data: T;
+}
+
+function isAdminPath(pathname: string): boolean {
+  return pathname.startsWith("/admin");
+}
+
+function buildLoginRedirect(request: NextRequest): NextResponse {
+  const nextUrl = request.nextUrl.clone();
+  const target = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  nextUrl.pathname = "/login";
+  nextUrl.search = `?next=${encodeURIComponent(target)}`;
+
+  const response = NextResponse.redirect(nextUrl);
+  response.cookies.set(AUTH_HINT_COOKIE_NAME, "", {
+    maxAge: 0,
+    path: "/",
+    sameSite: "lax",
+  });
+  return response;
+}
+
+function buildForbiddenRedirect(request: NextRequest): NextResponse {
+  const nextUrl = request.nextUrl.clone();
+  const from = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+  nextUrl.pathname = "/forbidden";
+  nextUrl.search = `?from=${encodeURIComponent(from)}`;
+  return NextResponse.redirect(nextUrl);
+}
+
+async function fetchRefreshedSession(
+  request: NextRequest,
+): Promise<{
+  memberRole: string;
+  refreshSetCookie: string | null;
+} | null> {
+  const cookieHeader = request.headers.get("cookie");
+  if (!cookieHeader) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(new URL(REFRESH_PATH, BACKEND_BASE_URL), {
+      method: "POST",
+      headers: {
+        cookie: cookieHeader,
+      },
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = (await response.json()) as RsData<AuthRefreshData>;
+    const data = payload?.data;
+    if (!data?.accessToken || !data.member?.role) {
+      return null;
+    }
+
+    return {
+      memberRole: data.member.role,
+      refreshSetCookie: response.headers.get("set-cookie"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const refreshCookie = request.cookies.get(REFRESH_COOKIE_NAME)?.value;
+  if (!refreshCookie) {
+    return buildLoginRedirect(request);
+  }
+
+  const session = await fetchRefreshedSession(request);
+  if (!session) {
+    return buildLoginRedirect(request);
+  }
+
+  if (isAdminPath(request.nextUrl.pathname) && session.memberRole !== "ADMIN") {
+    return buildForbiddenRedirect(request);
+  }
+
+  const hintValue = session.memberRole === "ADMIN" ? "admin" : "member";
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-maum-on-server-auth", hintValue);
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+  response.cookies.set(AUTH_HINT_COOKIE_NAME, hintValue, {
+    path: "/",
+    sameSite: "lax",
+  });
+
+  if (session.refreshSetCookie) {
+    response.headers.append("set-cookie", session.refreshSetCookie);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/dashboard/:path*",
+    "/letters/:path*",
+    "/stories/write/:path*",
+    "/admin/:path*",
+  ],
+};

--- a/front/src/app/admin/layout.tsx
+++ b/front/src/app/admin/layout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import AdminRoute from "@/components/auth/AdminRoute";
 import AdminShell from "@/components/admin/AdminShell";
 
 interface AdminLayoutProps {
@@ -8,9 +7,5 @@ interface AdminLayoutProps {
 
 /** 관리자 하위 라우트 전체에 인증/권한 가드를 적용한다. */
 export default function AdminLayout({ children }: AdminLayoutProps) {
-  return (
-    <AdminRoute>
-      <AdminShell>{children}</AdminShell>
-    </AdminRoute>
-  );
+  return <AdminShell>{children}</AdminShell>;
 }

--- a/front/src/app/dashboard/layout.tsx
+++ b/front/src/app/dashboard/layout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import ProtectedRoute from "@/components/auth/ProtectedRoute";
 
 interface DashboardLayoutProps {
   children: ReactNode;
@@ -7,5 +6,5 @@ interface DashboardLayoutProps {
 
 /** 대시보드 하위 라우트에 인증 가드를 일괄 적용한다. */
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
-  return <ProtectedRoute>{children}</ProtectedRoute>;
+  return <>{children}</>;
 }

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { Geist, Geist_Mono } from "next/font/google";
 import AuthBootstrap from "@/components/auth/AuthBootstrap";
 import AuthHintProvider from "@/components/auth/AuthHintProvider";
 import SiteFooter from "@/components/layout/SiteFooter";
 import {
   AUTH_HINT_COOKIE_NAME,
+  type AuthHintState,
   parseAuthHintCookieValue,
 } from "@/lib/auth/auth-hint-cookie";
 import "./globals.css";
@@ -36,9 +37,25 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const cookieStore = await cookies();
-  const authHint = parseAuthHintCookieValue(
+  const requestHeaders = await headers();
+  const serverValidatedHint = requestHeaders.get("x-maum-on-server-auth");
+  const cookieAuthHint = parseAuthHintCookieValue(
     cookieStore.get(AUTH_HINT_COOKIE_NAME)?.value,
   );
+  const authHint: AuthHintState =
+    serverValidatedHint === "admin"
+      ? {
+          isAuthenticated: true,
+          isAdmin: true,
+          isServerValidated: true,
+        }
+      : serverValidatedHint === "member"
+        ? {
+            isAuthenticated: true,
+            isAdmin: false,
+            isServerValidated: true,
+          }
+        : cookieAuthHint;
 
   return (
     <html lang="ko">

--- a/front/src/app/letters/layout.tsx
+++ b/front/src/app/letters/layout.tsx
@@ -1,7 +1,4 @@
-"use client";
-
 import type { ReactNode } from "react";
-import ProtectedRoute from "@/components/auth/ProtectedRoute";
 
 interface LettersLayoutProps {
   children: ReactNode;
@@ -9,5 +6,5 @@ interface LettersLayoutProps {
 
 /** letters subtree 전체에 인증 가드를 적용한다. */
 export default function LettersLayout({ children }: LettersLayoutProps) {
-  return <ProtectedRoute>{children}</ProtectedRoute>;
+  return <>{children}</>;
 }

--- a/front/src/app/stories/write/layout.tsx
+++ b/front/src/app/stories/write/layout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import ProtectedRoute from "@/components/auth/ProtectedRoute";
 
 interface StoryWriteLayoutProps {
   children: ReactNode;
@@ -7,5 +6,5 @@ interface StoryWriteLayoutProps {
 
 /** 고민 나누기 작성 화면은 로그인 사용자만 접근할 수 있다. */
 export default function StoryWriteLayout({ children }: StoryWriteLayoutProps) {
-  return <ProtectedRoute>{children}</ProtectedRoute>;
+  return <>{children}</>;
 }

--- a/front/src/components/auth/AuthBootstrap.tsx
+++ b/front/src/components/auth/AuthBootstrap.tsx
@@ -1,22 +1,31 @@
 "use client";
 
-import { useEffect } from "react";
-import { useHasRefreshCookieHint } from "@/components/auth/AuthHintProvider";
+import { useLayoutEffect } from "react";
+import { useAuthHint } from "@/components/auth/AuthHintProvider";
 import { restoreSession } from "@/lib/auth/auth-service";
-import { markRestoreFinished } from "@/lib/auth/auth-store";
+import {
+  applyAuthenticatedHintState,
+  markRestoreFinished,
+} from "@/lib/auth/auth-store";
 
 /** 앱 최초 렌더에서 세션 복원을 1회 수행하는 부트스트랩 컴포넌트. */
 export default function AuthBootstrap() {
-  const hasRefreshCookieHint = useHasRefreshCookieHint();
+  const authHint = useAuthHint();
 
-  useEffect(() => {
-    if (!hasRefreshCookieHint) {
+  useLayoutEffect(() => {
+    if (authHint.isServerValidated) {
+      applyAuthenticatedHintState(authHint);
+      markRestoreFinished();
+      return;
+    }
+
+    if (!authHint.isAuthenticated) {
       markRestoreFinished();
       return;
     }
 
     void restoreSession();
-  }, [hasRefreshCookieHint]);
+  }, [authHint]);
 
   return null;
 }

--- a/front/src/components/auth/AuthHintProvider.tsx
+++ b/front/src/components/auth/AuthHintProvider.tsx
@@ -6,6 +6,7 @@ import type { AuthHintState } from "@/lib/auth/auth-hint-cookie";
 const AuthHintContext = createContext<AuthHintState>({
   isAuthenticated: false,
   isAdmin: false,
+  isServerValidated: false,
 });
 
 export default function AuthHintProvider({

--- a/front/src/lib/auth/auth-hint-cookie.test.ts
+++ b/front/src/lib/auth/auth-hint-cookie.test.ts
@@ -6,6 +6,7 @@ describe("auth-hint-cookie", () => {
     expect(parseAuthHintCookieValue("admin")).toEqual({
       isAuthenticated: true,
       isAdmin: true,
+      isServerValidated: false,
     });
   });
 
@@ -13,6 +14,7 @@ describe("auth-hint-cookie", () => {
     expect(parseAuthHintCookieValue("member")).toEqual({
       isAuthenticated: true,
       isAdmin: false,
+      isServerValidated: false,
     });
   });
 
@@ -20,10 +22,12 @@ describe("auth-hint-cookie", () => {
     expect(parseAuthHintCookieValue(undefined)).toEqual({
       isAuthenticated: false,
       isAdmin: false,
+      isServerValidated: false,
     });
     expect(parseAuthHintCookieValue("unknown")).toEqual({
       isAuthenticated: false,
       isAdmin: false,
+      isServerValidated: false,
     });
   });
 });

--- a/front/src/lib/auth/auth-hint-cookie.ts
+++ b/front/src/lib/auth/auth-hint-cookie.ts
@@ -3,6 +3,7 @@ export const AUTH_HINT_COOKIE_NAME = "maumOnAuthHint";
 export interface AuthHintState {
   isAuthenticated: boolean;
   isAdmin: boolean;
+  isServerValidated: boolean;
 }
 
 export function parseAuthHintCookieValue(value: string | undefined): AuthHintState {
@@ -10,6 +11,7 @@ export function parseAuthHintCookieValue(value: string | undefined): AuthHintSta
     return {
       isAuthenticated: true,
       isAdmin: true,
+      isServerValidated: false,
     };
   }
 
@@ -17,12 +19,14 @@ export function parseAuthHintCookieValue(value: string | undefined): AuthHintSta
     return {
       isAuthenticated: true,
       isAdmin: false,
+      isServerValidated: false,
     };
   }
 
   return {
     isAuthenticated: false,
     isAdmin: false,
+    isServerValidated: false,
   };
 }
 

--- a/front/src/lib/auth/auth-store.ts
+++ b/front/src/lib/auth/auth-store.ts
@@ -3,6 +3,7 @@
 import { useSyncExternalStore } from "react";
 import { clearAccessToken, setAccessToken } from "@/lib/auth/token-store";
 import {
+  type AuthHintState,
   clearAuthHintCookie,
   persistAuthHintCookie,
 } from "@/lib/auth/auth-hint-cookie";
@@ -84,6 +85,18 @@ export function applyAuthenticatedMember(member: AuthMember): void {
     isAuthenticated: true,
     errorMessage: null,
     sessionRevision: nextRevision,
+  });
+}
+
+/** 서버에서 인증 확인된 요청의 최소 상태를 클라이언트 스토어에 반영한다. */
+export function applyAuthenticatedHintState(hint: AuthHintState): void {
+  if (!hint.isAuthenticated) {
+    return;
+  }
+
+  setState({
+    isAuthenticated: true,
+    errorMessage: null,
   });
 }
 


### PR DESCRIPTION
## 🔗 Issue 번호
- close #82 

## 🛠 작업 내역
- 보호 페이지 인증을 클라이언트 가드에서 서버로 옮김

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

