### PR TITLE
[Refactor]Diary 도메인 리팩토링

### DIFF
--- a/back/src/main/java/com/back/BackApplication.java
+++ b/back/src/main/java/com/back/BackApplication.java
@@ -2,8 +2,11 @@ package com.back;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+
+@EnableAsync
 @EnableScheduling
 @SpringBootApplication
 public class BackApplication {

--- a/back/src/main/java/com/back/diary/adapter/application/service/DiaryService.java
+++ b/back/src/main/java/com/back/diary/adapter/application/service/DiaryService.java
@@ -6,9 +6,11 @@ import com.back.diary.adapter.application.port.in.dto.DiaryRes;
 import com.back.diary.adapter.application.port.out.DiaryPort;
 import com.back.diary.domain.Diary;
 import com.back.global.exception.ServiceException;
+import com.back.image.application.event.ImageDeleteEvent;
 import com.back.image.application.service.ImageService;
 import com.back.image.domain.Image;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,58 +31,101 @@ public class DiaryService implements DiaryUseCase { // 1. Inbound Port 구현
 
     private final DiaryPort diaryRepositoryPort;
     private final ImageService imageService;
+    private final ApplicationEventPublisher eventPublisher;
 
-   @Override
+    @Override
     @Transactional
     public Long write(DiaryCreateReq req, MultipartFile image, Long memberId) {
-        LocalDate today = LocalDate.now();
-        LocalDateTime startOfToday = today.atStartOfDay();
-        LocalDateTime startOfTomorrow = today.plusDays(1).atStartOfDay();
+        validateDuplicateTodayDiary(memberId);
+        String uploadedUrl = uploadImageIfPresent(image);
+        List<String> extractedUrls = extractImageUrls(req.content());
 
-        boolean hasTodayDiary = diaryRepositoryPort.existsByMemberIdAndCreateDateBetween(
-                memberId,
-                startOfToday,
-                startOfTomorrow
-        );
+        Diary diary = Diary.create(memberId, "익명", req.title(), req.content(),
+                req.categoryName(), null, req.isPrivate());
+        diary.updateRepresentativeImage(uploadedUrl, req.imageUrl(), extractedUrls);
 
-        if (hasTodayDiary) {
-            throw new ServiceException("409-1", "오늘은 이미 일기를 작성했습니다. 기존 기록을 수정해주세요.");
+        Diary savedDiary = diaryRepositoryPort.save(diary);
+
+        List<String> allUsedImages = new ArrayList<>(extractedUrls);
+        if (diary.getImageUrl() != null && !allUsedImages.contains(diary.getImageUrl())) {
+            allUsedImages.add(diary.getImageUrl());
         }
-        List<String> imageUrls = extractImageUrls(req.content());
 
-       String representativeUrl = null;
-       if (image != null && !image.isEmpty()) {
-           representativeUrl = imageService.upload(image, "DIARY").getAccessUrl();
-       } else if (req.imageUrl() != null && !req.imageUrl().isBlank()) {
-           representativeUrl = req.imageUrl();
-       } else if (!imageUrls.isEmpty()) {
-           representativeUrl = imageUrls.get(0);
-       }
+        imageService.confirmUsage(allUsedImages, "DIARY", savedDiary.getId());
 
-        // 일기 생성 및 저장
-        Diary diary = Diary.builder()
-                .memberId(memberId)
-                .nickname("익명")
-                .title(req.title())
-                .content(req.content())
-                .imageUrl(representativeUrl)
-                .categoryName(req.categoryName())
-                .isPrivate(req.isPrivate())
-                .build();
-
-        return diaryRepositoryPort.save(diary).getId();
+        return savedDiary.getId();
     }
 
     @Override
+    @Transactional
+    public void modify(Long diaryId, DiaryCreateReq req, MultipartFile image, Long currentMemberId) {
+        Diary diary = findById(diaryId);
+        diary.validateOwner(currentMemberId);
+
+        String newImageUrl = diary.getImageUrl();
+
+        if (image != null && !image.isEmpty()) {
+            deleteImageIfExist(diary.getImageUrl());
+            newImageUrl = imageService.upload(image, "DIARY").getAccessUrl();
+        }
+        else if (diary.isImageChanged(req.imageUrl())) {
+            deleteImageIfExist(diary.getImageUrl());
+            newImageUrl = req.imageUrl();
+        }
+
+        diary.modify(req, newImageUrl);
+    }
+
+    @Override
+    @Transactional
+    public void delete(Long diaryId, Long currentMemberId) {
+        Diary diary = findById(diaryId);
+        diary.validateOwner(currentMemberId);
+
+        List<String> imagesToDelete = extractImageUrls(diary.getContent());
+        if (diary.getImageUrl() != null && !imagesToDelete.contains(diary.getImageUrl())) {
+            imagesToDelete.add(diary.getImageUrl());
+        }
+
+        // 1. DB에서 일기 먼저 삭제
+        diaryRepositoryPort.delete(diary);
+
+        // 2. 이미지 삭제는 이벤트를 발행하여 비동기로 처리
+        if (!imagesToDelete.isEmpty()) {
+            eventPublisher.publishEvent(new ImageDeleteEvent(imagesToDelete));
+        }
+    }
+
+    private Diary findById(Long id) {
+        return diaryRepositoryPort.findById(id)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
+    }
+
+    private String uploadImageIfPresent(MultipartFile image) {
+        return (image != null && !image.isEmpty())
+                ? imageService.upload(image, "DIARY").getAccessUrl()
+                : null;
+    }
+
+    private void deleteImageIfExist(String url) {
+        if (url != null && !url.isBlank()) {
+            imageService.delete(url);
+        }
+    }
+
+    private void validateDuplicateTodayDiary(Long memberId) {
+        LocalDate today = LocalDate.now();
+        if (diaryRepositoryPort.existsByMemberIdAndCreateDateBetween(
+                memberId, today.atStartOfDay(), today.plusDays(1).atStartOfDay())) {
+            throw new ServiceException("409-1", "오늘은 이미 일기를 작성했습니다.");
+        }
+    }
+
     public DiaryRes getDiary(Long diaryId, Long currentMemberId) {
         Diary diary = diaryRepositoryPort.findById(diaryId)
                 .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
-        if (diary.isPrivate()) {
-            if (currentMemberId == null || !diary.getMemberId().equals(currentMemberId)) {
-                throw new ServiceException("403-1", "비공개 일기입니다. 접근 권한이 없습니다.");
-            }
-        }
+        diary.validateAccess(currentMemberId);
 
         return DiaryRes.from(diary);
     }
@@ -97,45 +142,7 @@ public class DiaryService implements DiaryUseCase { // 1. Inbound Port 구현
                 .map(DiaryRes::from);
     }
 
-    @Override
-    @Transactional
-    public void modify(Long diaryId, DiaryCreateReq req, MultipartFile image, Long currentMemberId) {
-        Diary diary = diaryRepositoryPort.findById(diaryId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
-        if (!diary.getMemberId().equals(currentMemberId)) {
-            throw new ServiceException("403-1", "수정 권한이 없습니다.");
-        }
-
-        String newImageUrl = diary.getImageUrl();
-
-        if (image != null && !image.isEmpty()) {
-            if (diary.getImageUrl() != null) {
-                imageService.delete(diary.getImageUrl());
-            }
-            newImageUrl = imageService.upload(image, "DIARY").getAccessUrl();
-
-        } else if (req.imageUrl() != null && !req.imageUrl().isBlank()) {
-            if (diary.getImageUrl() != null && !diary.getImageUrl().equals(req.imageUrl())) {
-                imageService.delete(diary.getImageUrl());
-            }
-            newImageUrl = req.imageUrl();
-
-        } else {
-            if (diary.getImageUrl() != null) {
-                imageService.delete(diary.getImageUrl());
-            }
-            newImageUrl = null;
-        }
-
-        diary.modify(
-                req.title(),
-                req.content(),
-                newImageUrl,
-                req.categoryName(),
-                req.isPrivate()
-        );
-    }
 
     private List<String> extractImageUrls(String content) {
         List<String> urls = new ArrayList<>();
@@ -150,26 +157,5 @@ public class DiaryService implements DiaryUseCase { // 1. Inbound Port 구현
         return urls;
     }
 
-    @Override
-    @Transactional
-    public void delete(Long diaryId, Long currentMemberId) {
-        Diary diary = diaryRepositoryPort.findById(diaryId)
-                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 일기입니다."));
 
-        if (!diary.getMemberId().equals(currentMemberId)) {
-            throw new ServiceException("403-1", "삭제 권한이 없습니다.");
-        }
-
-        List<String> allImages = extractImageUrls(diary.getContent());
-
-        if (diary.getImageUrl() != null && !allImages.contains(diary.getImageUrl())) {
-            allImages.add(diary.getImageUrl());
-        }
-
-        for (String url : allImages) {
-            imageService.delete(url);
-        }
-
-        diaryRepositoryPort.delete(diary);
-    }
 }

--- a/back/src/main/java/com/back/diary/domain/Diary.java
+++ b/back/src/main/java/com/back/diary/domain/Diary.java
@@ -1,5 +1,7 @@
 package com.back.diary.domain;
 
+import com.back.diary.adapter.application.port.in.dto.DiaryCreateReq;
+import com.back.global.exception.ServiceException;
 import com.back.global.jpa.entity.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.Column;
@@ -8,6 +10,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @Getter
@@ -51,12 +55,65 @@ public class Diary extends BaseEntity {
         this.isPrivate = isPrivate;
     }
 
+    public static Diary create(Long memberId, String nickname, String title, String content,
+                               String categoryName, String imageUrl, boolean isPrivate) {
+        String finalNickname = (nickname == null || nickname.isBlank()) ? "익명" : nickname;
+
+        return Diary.builder()
+                .memberId(memberId)
+                .nickname(finalNickname)
+                .title(title)
+                .content(content)
+                .categoryName(categoryName)
+                .imageUrl(imageUrl)
+                .isPrivate(isPrivate)
+                .build();
+    }
+
     public void modify(String title, String content,String newImageUrl, String categoryName,boolean isPrivate) {
         this.title = title;
         this.content = content;
         this.categoryName = categoryName;
         this.imageUrl  = newImageUrl;
         this.isPrivate = isPrivate;
+    }
+
+    public void updateRepresentativeImage(String uploadedUrl, String requestUrl, List<String> extractedUrls) {
+        if (uploadedUrl != null) {
+            this.imageUrl = uploadedUrl;
+        } else if (requestUrl != null && !requestUrl.isBlank()) {
+            this.imageUrl = requestUrl;
+        } else if (!extractedUrls.isEmpty()) {
+            this.imageUrl = extractedUrls.get(0);
+        } else {
+            this.imageUrl = null;
+        }
+    }
+
+    public void validateOwner(Long currentMemberId) {
+        if (!this.memberId.equals(currentMemberId)) {
+            throw new ServiceException("403-1", "해당 일기에 대한 권한이 없습니다.");
+        }
+    }
+
+    public void validateAccess(Long currentMemberId) {
+        if (this.isPrivate && (currentMemberId == null || !this.memberId.equals(currentMemberId))) {
+            throw new ServiceException("403-1", "비공개 일기입니다. 접근 권한이 없습니다.");
+        }
+    }
+
+    public void modify(DiaryCreateReq req, String newImageUrl) {
+        // 상태 변경 로직만 집중
+        this.title = req.title();
+        this.content = req.content();
+        this.categoryName = req.categoryName();
+        this.imageUrl = newImageUrl;
+        this.isPrivate = req.isPrivate();
+    }
+
+    public boolean isImageChanged(String requestImageUrl) {
+        if (this.imageUrl == null) return requestImageUrl != null;
+        return !this.imageUrl.equals(requestImageUrl);
     }
 
 

--- a/back/src/main/java/com/back/image/adapter/out/persistence/ImageRepository.java
+++ b/back/src/main/java/com/back/image/adapter/out/persistence/ImageRepository.java
@@ -2,8 +2,14 @@ package com.back.image.adapter.out.persistence;
 
 import com.back.image.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
     Optional<Image> findByStoredName(String storedName);
+
+    List<Image> findAllByStoredNameIn(List<String> storedNames);
+    List<Image> findAllByStatusAndCreateDateBefore(Image.ImageStatus status, LocalDateTime dateTime);
 }

--- a/back/src/main/java/com/back/image/application/event/ImageDeleteEvent.java
+++ b/back/src/main/java/com/back/image/application/event/ImageDeleteEvent.java
@@ -1,0 +1,7 @@
+package com.back.image.application.event;
+
+import java.util.List;
+
+// com.back.image.application.event.ImageDeleteEvent.java
+public record ImageDeleteEvent(List<String> imageUrls) {
+}

--- a/back/src/main/java/com/back/image/application/event/ImageEventListener.java
+++ b/back/src/main/java/com/back/image/application/event/ImageEventListener.java
@@ -1,0 +1,22 @@
+package com.back.image.application.event;
+
+import com.back.image.application.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageEventListener {
+
+    private final ImageService imageService;
+
+    @Async
+    @EventListener
+    public void handleImageDelete(ImageDeleteEvent event) {
+        for (String url : event.imageUrls()) {
+            imageService.delete(url);
+        }
+    }
+}

--- a/back/src/main/java/com/back/image/application/scheduler/ImageCleaner.java
+++ b/back/src/main/java/com/back/image/application/scheduler/ImageCleaner.java
@@ -1,0 +1,53 @@
+package com.back.image.application.scheduler;
+
+import com.back.image.adapter.out.persistence.ImageRepository;
+import com.back.image.application.service.ImageService;
+import com.back.image.domain.Image;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// com.back.image.application.scheduler.ImageCleaner.java
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImageCleaner {
+
+    private final ImageRepository imageRepository;
+    private final ImageService imageService;
+
+    // 매일 새벽 3시에 실행 (Cron: 초 분 시 일 월 요일)
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupUnusedImages() {
+        log.info("유령 이미지 청소 작업을 시작합니다.");
+        
+        // 24시간 전 기준 시간 계산
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+        
+        // 대상 조회
+        List<Image> unusedImages = imageRepository.findAllByStatusAndCreateDateBefore(
+                Image.ImageStatus.PENDING,
+                threshold
+        );
+
+        log.info("삭제 대상 이미지 개수: {}개", unusedImages.size());
+
+        for (Image image : unusedImages) {
+            try {
+                // 기존에 만들어둔 delete 로직 재활용 (물리 파일 + DB 삭제)
+                imageService.delete(image.getAccessUrl());
+                log.info("유령 이미지 삭제 완료: {}", image.getStoredName());
+            } catch (Exception e) {
+                log.error("이미지 삭제 중 오류 발생: {}", image.getStoredName(), e);
+            }
+        }
+        
+        log.info("유령 이미지 청소 작업을 마칩니다.");
+    }
+}

--- a/back/src/main/java/com/back/image/application/service/ImageService.java
+++ b/back/src/main/java/com/back/image/application/service/ImageService.java
@@ -3,7 +3,10 @@ package com.back.image.application.service;
 import com.back.image.domain.Image;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface ImageService {
     Image upload(MultipartFile file, String refType);
     void delete(String fileUrl);
+    void confirmUsage(List<String> imageUrls, String refType, Long refId);
 }

--- a/back/src/main/java/com/back/image/domain/Image.java
+++ b/back/src/main/java/com/back/image/domain/Image.java
@@ -1,11 +1,8 @@
 package com.back.image.domain;
 
 import com.back.global.jpa.entity.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
-
 
 @Entity
 @Getter
@@ -30,8 +27,29 @@ public class Image extends BaseEntity {
     private String referenceType;
     private Long referenceId;
 
+    // 1. 상태 필드 선언 (중복 제거됨)
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ImageStatus status = ImageStatus.PENDING;
+
+    // 2. 내부 Enum 선언 (중복 제거됨)
+    public enum ImageStatus {
+        PENDING,   // 업로드 직후, 아직 도메인과 연결 안 됨
+        CONNECTED, // 일기 등 도메인 객체와 연결됨
+        DELETED    // 논리적 삭제 상태
+    }
+
+    // 3. 비즈니스 로직 메서드 (중복 제거됨)
+
+    // 도메인 연결 메서드
     public void connectTo(String refType, Long refId) {
         this.referenceType = refType;
         this.referenceId = refId;
+        this.status = ImageStatus.CONNECTED;
+    }
+
+    // 논리 삭제 메서드
+    public void softDelete() {
+        this.status = ImageStatus.DELETED;
     }
 }

--- a/back/src/main/java/com/back/image/infrastructure/LocalImageService.java
+++ b/back/src/main/java/com/back/image/infrastructure/LocalImageService.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -70,9 +71,6 @@ public class LocalImageService implements ImageService {
             return;
         }
 
-        // 1. 저장된 파일명(storedName)만 안전하게 추출
-        // URL이 "http://localhost:8080/gen/abc.png" 이든 "/gen/abc.png" 이든
-        // 마지막 '/' 뒤의 문자열만 가져오도록 개선합니다.
         String storedName = fileUrl.contains("/")
                 ? fileUrl.substring(fileUrl.lastIndexOf("/") + 1)
                 : fileUrl;
@@ -114,5 +112,27 @@ public class LocalImageService implements ImageService {
         if (!StringUtils.hasText(fileName)) return "";
         int pos = fileName.lastIndexOf(".");
         return fileName.substring(pos + 1);
+    }
+
+    @Override
+    @Transactional
+    public void confirmUsage(List<String> imageUrls, String refType, Long refId) {
+        if (imageUrls == null || imageUrls.isEmpty()) return;
+
+
+        List<String> storedNames = imageUrls.stream()
+                .map(this::extractStoredName)
+                .toList();
+
+
+        imageRepository.findAllByStoredNameIn(storedNames)
+                .forEach(image -> image.connectTo(refType, refId));
+    }
+
+    private String extractStoredName(String fileUrl) {
+        if (fileUrl == null) return "";
+        return fileUrl.contains("/")
+                ? fileUrl.substring(fileUrl.lastIndexOf("/") + 1)
+                : fileUrl;
     }
 }

--- a/back/src/main/resources/application.yaml
+++ b/back/src/main/resources/application.yaml
@@ -39,7 +39,7 @@ spring:
               - profile_nickname
   docker:
     compose:
-      file: docker-compose.dev.yml
+      file: back/docker-compose.dev.yml
       lifecycle-management: start_only
       enabled: true
   data:


### PR DESCRIPTION
## 🔗 Issue 번호
- close #134 

## 🛠 작업 내역
-업로드 시 PENDING 상태 부여 및 게시글 저장 시 CONNECTED 전환 로직 구현
-스케줄러(@Scheduled)를 도입하여 24시간 이상 방치된 PENDING 상태 이미지 자동 삭제 구현
-서비스 계층의 비즈니스 로직(권한 검증, 이미지 추출 등)을 Diary 및 Image 엔티티 내부로 이동

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

