### PR TITLE
[Feat] Letter 편지 수락 구현

### DIFF
--- a/back/src/main/java/com/back/letter/adapter/in/web/LetterController.java
+++ b/back/src/main/java/com/back/letter/adapter/in/web/LetterController.java
@@ -89,6 +89,17 @@ public class LetterController {
         return ResponseEntity.ok(new RsData<>("200-5", "편지 수락 성공", null));
     }
 
+    @PostMapping("/{id}/reject")
+    public ResponseEntity<RsData<Void>> rejectLetter(
+            @PathVariable long id,
+            @AuthenticationPrincipal AuthenticatedMember authMember
+    ) {
+        if (authMember == null) throw AuthErrorCode.AUTHENTICATION_REQUIRED.toException();
+
+        sendLetterUseCase.rejectLetter(id, authMember.memberId());
+        return ResponseEntity.ok(new RsData<>("200-8", "편지를 거절하여 새로운 수신자에게 전달되었습니다."));
+    }
+
     @PostMapping("/{id}/writing")
     public ResponseEntity<RsData<Void>> updateWritingStatus(
             @PathVariable long id,

--- a/back/src/main/java/com/back/letter/adapter/out/persistence/LetterPersistenceAdapter.java
+++ b/back/src/main/java/com/back/letter/adapter/out/persistence/LetterPersistenceAdapter.java
@@ -41,8 +41,8 @@ public class LetterPersistenceAdapter implements LetterPort {
     }
 
     @Override
-    public Optional<Member> findRandomMemberExceptMe(long myId) {
-        return letterRepository.findRandomMemberExceptMe(myId);
+    public Optional<Member> findRandomMemberExceptMe(List<Long> excludeIds) {
+        return letterRepository.findRandomMemberExceptMe(excludeIds);
     }
     @Override
     public Optional<Letter> findLatestReceived(Long receiverId) {

--- a/back/src/main/java/com/back/letter/adapter/out/persistence/repository/LetterRepository.java
+++ b/back/src/main/java/com/back/letter/adapter/out/persistence/repository/LetterRepository.java
@@ -22,12 +22,12 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
     Page<Letter> findBySenderId(@Param("memberId") Long memberId, Pageable pageable);
 
     @Query(value = "SELECT * FROM members " +
-            "WHERE id != :myId " +
+            "WHERE id NOT IN (:excludeIds) " + // != 대신 NOT IN 사용
             "AND status = 'ACTIVE' " +
             "AND random_receive_allowed = true " +
-            "ORDER BY RANDOM() LIMIT 1", // RAND()를 RANDOM()으로 변경
+            "ORDER BY RANDOM() LIMIT 1",
             nativeQuery = true)
-    Optional<Member> findRandomMemberExceptMe(@Param("myId") long myId);
+    Optional<Member> findRandomMemberExceptMe(@Param("excludeIds") List<Long> excludeIds);
     Optional<Letter> findFirstByReceiverIdOrderByCreateDateDesc(Long receiverId);
     Optional<Letter> findFirstBySenderIdOrderByCreateDateDesc(Long senderId);
     long countByReceiverId(Long receiverId);

--- a/back/src/main/java/com/back/letter/application/port/in/SendLetterUseCase.java
+++ b/back/src/main/java/com/back/letter/application/port/in/SendLetterUseCase.java
@@ -9,4 +9,5 @@ public interface SendLetterUseCase {
     void acceptLetter(long id, long accessorId);
     void updateWritingStatus(long id);
     void reassignUnreadLetters();
+    void rejectLetter(long id, long memberId);
 }

--- a/back/src/main/java/com/back/letter/application/port/out/LetterPort.java
+++ b/back/src/main/java/com/back/letter/application/port/out/LetterPort.java
@@ -14,7 +14,7 @@ public interface LetterPort {
     Optional<Letter> findById(long id);
     Page<Letter> findByReceiverId(long memberId, Pageable pageable);
     Page<Letter> findBySenderId(long memberId, Pageable pageable);
-    Optional<Member> findRandomMemberExceptMe(long myId);
+    Optional<Member> findRandomMemberExceptMe(List<Long> excludeIds);
     Optional<Letter> findLatestReceived(Long receiverId);
 
     Optional<Letter> findLatestSent(Long senderId);

--- a/back/src/main/java/com/back/letter/application/service/LetterService.java
+++ b/back/src/main/java/com/back/letter/application/service/LetterService.java
@@ -93,6 +93,28 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
 
     @Override
     @Transactional
+    public void rejectLetter(long id, long accessorId) {
+        Letter letter = letterPort.findById(id)
+                .orElseThrow(() -> new ServiceException("404-1", "편지를 찾을 수 없습니다."));
+
+        // 1. 도메인 로직: 수신자 비우고 상태 초기화
+        letter.reject(accessorId);
+
+        // 2. 발송자(sender)와 거절자(accessorId) 둘 다 제외하고 새 수신자 찾기
+        // LetterRepository에 List<Long>을 받는 findRandomMemberExcept 메서드가 있어야 합니다.
+        Member newReceiver = letterPort.findRandomMemberExceptMe(
+                List.of(letter.getSender().getId(), accessorId)
+        ).orElseThrow(() -> new ServiceException("404-2", "편지를 전달할 수 있는 다른 유저가 없습니다."));
+
+        // 3. 재배달
+        letter.dispatch(newReceiver);
+
+        // 알림 이벤트 발행 등
+        eventPublisher.publishEvent(new LetterEvents.LetterSentEvent(letter.getId(), newReceiver.getId()));
+    }
+
+    @Override
+    @Transactional
     public void updateWritingStatus(long id) {
         letterRedisRepository.setWritingStatus(id);
 
@@ -108,7 +130,7 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
         List<Letter> expiredLetters = letterPort.findUnreadLettersExceeding(expirationTime);
 
         for (Letter letter : expiredLetters) {
-            letterPort.findRandomMemberExceptMe(letter.getSender().getId())
+            letterPort.findRandomMemberExceptMe(List.of(letter.getSender().getId()))
                     .ifPresent(newReceiver -> {
                         letter.reassignReceiver(newReceiver);
                         eventPublisher.publishEvent(new LetterEvents.LetterSentEvent(letter.getId(), newReceiver.getId()));
@@ -121,10 +143,6 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
     public LetterInfoRes getLetter(long id, long accessorId) {
         Letter letter = letterPort.findById(id)
                 .orElseThrow(() -> new ServiceException("404-1", "편지를 찾을 수 없습니다."));
-
-        if (!letter.getSender().getId().equals(accessorId) && letter.getStatus() == LetterStatus.SENT) {
-            acceptLetter(id, accessorId);
-        }
 
         return LetterInfoRes.from(letter);
     }
@@ -174,10 +192,10 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
         Long rId = letterRedisRepository.getRandomReceiver();
         if (rId != null && !rId.equals(senderId)) {
             return memberRepository.findById(rId)
-                    .orElseGet(() -> letterPort.findRandomMemberExceptMe(senderId)
+                    .orElseGet(() -> letterPort.findRandomMemberExceptMe(List.of(senderId))
                             .orElseThrow(() -> new ServiceException("404-1", "수신 가능한 사용자가 없습니다.")));
         }
-        return letterPort.findRandomMemberExceptMe(senderId)
+        return letterPort.findRandomMemberExceptMe(List.of(senderId))
                 .orElseThrow(() -> new ServiceException("404-1", "수신 가능한 사용자가 없습니다."));
     }
 }

--- a/back/src/main/java/com/back/letter/domain/Letter.java
+++ b/back/src/main/java/com/back/letter/domain/Letter.java
@@ -64,6 +64,20 @@ public class Letter extends BaseEntity {
     }
 
     /**
+     * 수신자가 편지를 거절
+     */
+    public void reject(long accessorId) {
+        verifyReceiver(accessorId);
+
+        if (this.status != LetterStatus.SENT) {
+            throw new ServiceException("400-3", "대기 중인 편지만 거절할 수 있습니다.");
+        }
+
+        this.receiver = null;
+        this.status = null;
+    }
+
+    /**
      * 답장 작성 완료
      */
     public void reply(String replyContent, long accessorId) {

--- a/back/src/test/java/com/back/letter/service/LetterServiceTest.java
+++ b/back/src/test/java/com/back/letter/service/LetterServiceTest.java
@@ -121,7 +121,7 @@ class LetterServiceTest {
             given(memberRepository.findById(senderId)).willReturn(Optional.of(createMember(senderId, "S")));
 
             given(letterRedisRepository.getRandomReceiver()).willReturn(null);
-            given(letterPort.findRandomMemberExceptMe(senderId)).willReturn(Optional.empty());
+            given(letterPort.findRandomMemberExceptMe(List.of(senderId))).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> letterService.createLetterAndDirectSendLetter(new CreateLetterReq("T", "C"), senderId))

--- a/front/src/app/letters/mailbox/receive/[id]/page.tsx
+++ b/front/src/app/letters/mailbox/receive/[id]/page.tsx
@@ -11,6 +11,8 @@ import {
   Send,
   MessageSquareText,
   Flag,
+  Check,
+  X,
 } from "lucide-react";
 import MainHeader from "@/components/layout/MainHeader";
 import { requestData, requestVoid } from "@/lib/api/http-client";
@@ -26,6 +28,7 @@ interface ReceivedLetterDetail {
   content: string;
   createdDate: string;
   senderNickname: string;
+  status: "SENT" | "ACCEPTED" | "REPLIED"; // 상태 타입 정의
   replied: boolean;
   replyContent?: string;
 }
@@ -35,42 +38,27 @@ export default function ReceivedLetterDetailPage() {
   const params = useParams();
   const { isAuthenticated } = useAuthStore();
 
-  // 상태 및 Ref 관리
   const isNotifiedRef = useRef(false);
   const writingTimeoutRef = useRef<number | null>(null);
+
   const [letter, setLetter] = useState<ReceivedLetterDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isProcessing, setIsProcessing] = useState(false);
   const [replyContent, setReplyContent] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
   const [isReportDialogOpen, setIsReportDialogOpen] = useState(false);
   const [reportDialogKey, setReportDialogKey] = useState(0);
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
-  const [reportErrorMessage, setReportErrorMessage] = useState<string | null>(null);
-  const [reportNoticeMessage, setReportNoticeMessage] = useState<string | null>(null);
+  const [reportErrorMessage, setReportErrorMessage] = useState<string | null>(
+    null,
+  );
+  const [reportNoticeMessage, setReportNoticeMessage] = useState<string | null>(
+    null,
+  );
 
   const letterId = typeof params.id === "string" ? params.id : "";
 
-  // 1. [수정] 작성 중 신호 전송 함수 (최상단으로 이동 및 통합)
-  const notifyWriting = useCallback((id: string) => {
-    if (isNotifiedRef.current) return; // 이미 보냈다면 무시
-
-    if (writingTimeoutRef.current !== null) {
-      window.clearTimeout(writingTimeoutRef.current);
-    }
-
-    writingTimeoutRef.current = window.setTimeout(async () => {
-      try {
-        await requestVoid(`/api/v1/letters/${id}/writing`, {
-          method: "POST",
-        });
-        isNotifiedRef.current = true; // ✅ 성공적으로 보냈음을 기록
-      } catch {
-        console.error("작성 중 신호 전송 실패");
-      }
-    }, 1000);
-  }, []);
-
-  // 2. [수정] 돌아가기 함수 (내부의 잘못된 useCallback 제거)
   const handleGoBack = useCallback(() => {
     if (typeof window !== "undefined" && window.history.length > 1) {
       router.back();
@@ -79,7 +67,7 @@ export default function ReceivedLetterDetailPage() {
     }
   }, [router]);
 
-  // 3. 데이터 로드 및 읽음 처리
+  // 1. 데이터 로드 (자동 수락 API 호출 제거됨)
   useEffect(() => {
     const initPage = async () => {
       if (!letterId) return;
@@ -87,17 +75,10 @@ export default function ReceivedLetterDetailPage() {
         const data = await requestData<ReceivedLetterDetail>(
           `/api/v1/letters/${letterId}`,
         );
+        console.log("편지 상태 확인:", data.status);
         setLetter(data);
-
-        // 읽음 처리 알림 (ACCEPTED)
-        if (data && !data.replied) {
-          await requestVoid(`/api/v1/letters/${letterId}/accept`, {
-            method: "POST",
-          });
-        }
       } catch (error) {
-        console.error("편지 로드 실패", error);
-        alert("존재하지 않는 편지입니다.");
+        alert("편지를 불러올 수 없습니다.");
         handleGoBack();
       } finally {
         setIsLoading(false);
@@ -106,70 +87,47 @@ export default function ReceivedLetterDetailPage() {
     void initPage();
   }, [letterId, handleGoBack]);
 
-  // 4. 타이머 정리
-  useEffect(() => {
-    return () => {
-      if (writingTimeoutRef.current !== null) {
-        window.clearTimeout(writingTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const value = e.target.value;
-    setReplyContent(value);
-
-    if (value.trim().length > 0 && !letter?.replied && letterId) {
-      notifyWriting(letterId);
-    }
-  };
-
-  const handleReplySubmit = async () => {
-    if (!replyContent.trim() || !letterId) return;
-
-    setIsSubmitting(true);
+  // 2. 수락 핸들러
+  const handleAccept = async () => {
+    if (!letterId || isProcessing) return;
+    setIsProcessing(true);
     try {
-      await requestVoid(`/api/v1/letters/${letterId}/reply`, {
+      await requestVoid(`/api/v1/letters/${letterId}/accept`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ replyContent: replyContent }),
       });
-
-      setLetter((prev) =>
-        prev ? { ...prev, replied: true, replyContent: replyContent } : null,
-      );
-
-      alert("답장이 바다로 전송되었습니다.");
-      router.refresh();
-      router.push("/letters/mailbox");
+      setLetter((prev) => (prev ? { ...prev, status: "ACCEPTED" } : null));
     } catch (error) {
-      alert(toErrorMessage(error) || "답장 전송에 실패했습니다.");
+      alert(toErrorMessage(error));
     } finally {
-      setIsSubmitting(false);
+      setIsProcessing(false);
     }
   };
 
-  function openReportDialog(): void {
-    if (!letter) {
+  // 3. 거절 핸들러
+  const handleReject = async () => {
+    if (!letterId || isProcessing) return;
+    if (
+      !confirm(
+        "이 고민을 다른 분께 전달할까요? 거절하시면 다시 읽을 수 없습니다.",
+      )
+    )
       return;
+
+    setIsProcessing(true);
+    try {
+      await requestVoid(`/api/v1/letters/${letterId}/reject`, {
+        method: "POST",
+      });
+      alert("다른 누군가에게 고민이 전달되었습니다.");
+      router.push("/letters/mailbox/receive");
+    } catch (error) {
+      alert(toErrorMessage(error));
+      setIsProcessing(false);
     }
+  };
 
-    if (!isAuthenticated) {
-      router.push(`/login?next=${encodeURIComponent(`/letters/mailbox/receive/${letter.id}`)}`);
-      return;
-    }
-
-    setReportErrorMessage(null);
-    setReportNoticeMessage(null);
-    setReportDialogKey((prev) => prev + 1);
-    setIsReportDialogOpen(true);
-  }
-
-  async function submitReport(reason: ReportReasonCode, content: string): Promise<void> {
-    if (!letter || isSubmittingReport) {
-      return;
-    }
-
+  const submitReport = async (reason: ReportReasonCode, content: string) => {
+    if (!letter || isSubmittingReport) return;
     setIsSubmittingReport(true);
     setReportErrorMessage(null);
 
@@ -178,131 +136,184 @@ export default function ReceivedLetterDetailPage() {
         targetId: letter.id,
         targetType: "LETTER",
         reason,
-        content: content.trim().length > 0 ? content.trim() : undefined,
+        content: content.trim(),
       });
+
+      // 성공 시 처리
       setIsReportDialogOpen(false);
-      setReportNoticeMessage("신고가 접수되었습니다.");
-    } catch (error: unknown) {
+      setReportNoticeMessage("신고가 정상적으로 접수되었습니다.");
+      alert("신고가 접수되었습니다.");
+
+      // 다이얼로그 초기화를 위해 키 값 변경
+      setReportDialogKey((prev) => prev + 1);
+    } catch (error) {
       setReportErrorMessage(toErrorMessage(error));
     } finally {
       setIsSubmittingReport(false);
     }
-  }
+  };
 
-  if (isLoading) {
+  const notifyWriting = useCallback((id: string) => {
+    if (isNotifiedRef.current) return;
+    if (writingTimeoutRef.current !== null)
+      window.clearTimeout(writingTimeoutRef.current);
+    writingTimeoutRef.current = window.setTimeout(async () => {
+      try {
+        await requestVoid(`/api/v1/letters/${id}/writing`, { method: "POST" });
+        isNotifiedRef.current = true;
+      } catch {
+        console.error("작성 중 신호 실패");
+      }
+    }, 1000);
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = e.target.value;
+    setReplyContent(value);
+    if (value.trim().length > 0 && letter?.status === "ACCEPTED" && letterId) {
+      notifyWriting(letterId);
+    }
+  };
+
+  const handleReplySubmit = async () => {
+    if (!replyContent.trim() || !letterId) return;
+    setIsSubmitting(true);
+    try {
+      await requestVoid(`/api/v1/letters/${letterId}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ replyContent }),
+      });
+      setLetter((prev) =>
+        prev
+          ? { ...prev, replied: true, replyContent, status: "REPLIED" }
+          : null,
+      );
+      alert("답장이 바다로 전송되었습니다.");
+      router.push("/letters/mailbox");
+    } catch (error) {
+      alert(toErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (isLoading)
     return (
-      <div className="min-h-screen bg-[#EBF5FF] flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-sky-400"></div>
+      <div className="min-h-screen bg-[#EBF5FF] flex items-center justify-center font-bold">
+        로딩 중...
       </div>
     );
-  }
-
   if (!letter) return null;
 
+  // 핵심: 상태가 SENT인 경우에만 수락/거절을 기다림
+  const isPending = letter.status === "SENT";
+
   return (
-    <div className="min-h-screen bg-[#EBF5FF] pb-20 font-sans text-slate-800">
+    <div className="min-h-screen bg-[#EBF5FF] pb-40 font-sans text-slate-800">
       <div className="mx-auto w-full max-w-6xl px-6 pt-7">
         <MainHeader />
       </div>
 
       <main className="mx-auto mt-10 max-w-4xl px-6">
-        {/* 상단 버튼 및 타이틀 */}
-        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handleGoBack}
-              className="inline-flex items-center gap-2 self-start rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-[#5e7ea5] ring-1 ring-[#d8e7f7] shadow-sm transition hover:bg-white"
-            >
-              <ChevronLeft size={16} />
-              돌아가기
-            </button>
-            <button
-              type="button"
-              onClick={openReportDialog}
-              className="inline-flex items-center gap-2 self-start rounded-full bg-[#fff4f4] px-4 py-2 text-sm font-semibold text-[#b56060] ring-1 ring-[#f2dede] shadow-sm transition hover:bg-[#ffecec]"
-            >
-              <Flag size={15} />
-              신고
-            </button>
-          </div>
+        <div className="mb-8 flex justify-between items-center">
+          <button
+            onClick={handleGoBack}
+            className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-[#5e7ea5] shadow-sm transition hover:bg-white"
+          >
+            <ChevronLeft size={16} /> 돌아가기
+          </button>
           <div className="inline-flex items-center gap-2 rounded-full bg-white/60 px-4 py-2 text-sm font-semibold text-sky-900">
-            <MailOpen size={18} className="text-sky-400" />
-            도착한 마음
+            <MailOpen size={18} className="text-sky-400" /> 도착한 마음
           </div>
         </div>
-
-        {reportNoticeMessage ? (
-          <div className="mb-4 rounded-[14px] border border-[#d6eadb] bg-[#f1fbf4] px-4 py-3 text-sm text-[#3f7d50]">
-            {reportNoticeMessage}
-          </div>
-        ) : null}
 
         {/* 편지 본문 카드 */}
         <section className="bg-white/90 backdrop-blur-md rounded-[3rem] p-10 md:p-14 shadow-lg border border-white relative overflow-hidden">
           <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-sky-100 via-sky-300 to-sky-100" />
           <div className="flex justify-between items-center mb-12 border-b border-slate-100 pb-8 text-slate-400 text-sm italic font-serif">
-            <span>From. {letter.senderNickname || "익명의 누군가"}</span>
+            <span>From. {letter.senderNickname || "익명"}</span>
             <div className="flex items-center gap-2 not-italic font-sans font-medium bg-slate-50 px-4 py-1.5 rounded-full">
               <Calendar size={16} className="text-sky-300" />
               {new Date(letter.createdDate).toLocaleDateString()}
             </div>
           </div>
-          <div className="mb-10">
-            <h2 className="text-3xl font-bold text-slate-900 mb-8 leading-tight">
-              {letter.title}
-            </h2>
-            <div className="text-slate-700 text-xl leading-relaxed font-serif whitespace-pre-wrap italic">
-              {letter.content}
-            </div>
-          </div>
-          <div className="pt-8 border-t border-slate-50 flex justify-end">
-            <Waves size={24} className="text-sky-100" />
+          <h2 className="text-3xl font-bold text-slate-900 mb-8 leading-tight">
+            {letter.title}
+          </h2>
+          <div className="text-slate-700 text-xl leading-relaxed font-serif whitespace-pre-wrap italic">
+            {letter.content}
           </div>
         </section>
 
-        {/* 답장 섹션 */}
-        <section className="mt-12">
-          {letter.replied ? (
-            <div className="bg-emerald-50/60 backdrop-blur-md rounded-[2.5rem] p-10 border border-emerald-100">
-              <div className="flex items-center gap-3 mb-6 text-emerald-700 font-bold">
-                <Heart size={20} /> <span>내가 보낸 따뜻한 답장</span>
+        {/* 인터랙션 영역 */}
+        {isPending ? (
+          /* [상태 1] 수락/거절 버튼 바 */
+          <div className="fixed bottom-10 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-3rem)] max-w-2xl animate-in slide-in-from-bottom-10 duration-500">
+            <div className="bg-white/95 backdrop-blur-xl p-6 rounded-[2.5rem] shadow-2xl border border-white flex flex-col sm:flex-row items-center justify-between gap-6">
+              <div className="text-center sm:text-left">
+                <p className="font-bold text-slate-800 text-lg">
+                  이 고민을 들어주시겠어요?
+                </p>
+                <p className="text-sm text-slate-500">
+                  수락하시면 답장을 남길 수 있습니다.
+                </p>
               </div>
-              <div className="text-slate-700 text-lg leading-relaxed font-serif italic whitespace-pre-wrap">
-                {letter.replyContent}
-              </div>
-            </div>
-          ) : (
-            <div className="bg-white/60 backdrop-blur-md rounded-[3rem] p-8 md:p-10 border border-white shadow-lg">
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-3 text-sky-700 font-bold">
-                  <MessageSquareText size={20} />{" "}
-                  <span>이 편지에 답장을 남겨보세요</span>
-                </div>
-              </div>
-              <textarea
-                value={replyContent}
-                onChange={handleInputChange}
-                placeholder="따뜻한 말 한마디가 누군가에게 큰 힘이 됩니다..."
-                className="w-full h-48 bg-white/50 rounded-2xl p-6 text-lg font-serif italic outline-none focus:ring-2 ring-sky-200 border border-slate-100 transition-all resize-none"
-              />
-              <div className="mt-6 flex justify-end">
+              <div className="flex gap-3 w-full sm:w-auto">
                 <button
-                  onClick={handleReplySubmit}
-                  disabled={isSubmitting || !replyContent.trim()}
-                  className={`flex items-center gap-2 px-8 py-4 rounded-full font-bold transition-all shadow-lg ${
-                    isSubmitting || !replyContent.trim()
-                      ? "bg-slate-200 text-slate-400"
-                      : "bg-sky-500 text-white hover:bg-sky-600 shadow-sky-200"
-                  }`}
+                  onClick={handleReject}
+                  disabled={isProcessing}
+                  className="flex-1 sm:flex-none px-6 py-4 rounded-full bg-slate-100 text-slate-600 font-bold hover:bg-red-50 hover:text-red-500 transition-all flex items-center justify-center gap-2"
                 >
-                  {isSubmitting ? "전송 중..." : "답장 띄워보내기"}{" "}
-                  <Send size={18} />
+                  <X size={18} /> 거절
+                </button>
+                <button
+                  onClick={handleAccept}
+                  disabled={isProcessing}
+                  className="flex-1 sm:flex-none px-8 py-4 rounded-full bg-sky-500 text-white font-bold hover:bg-sky-600 shadow-lg shadow-sky-200 transition-all flex items-center justify-center gap-2"
+                >
+                  <Check size={18} /> 수락하기
                 </button>
               </div>
             </div>
-          )}
-        </section>
+          </div>
+        ) : (
+          /* [상태 2] 답장 섹션 (상태가 ACCEPTED 이상일 때만 보임) */
+          <section className="mt-12 animate-in fade-in zoom-in-95 duration-700">
+            {letter.replied ? (
+              <div className="bg-emerald-50/60 rounded-[2.5rem] p-10 border border-emerald-100">
+                <div className="flex items-center gap-3 mb-6 text-emerald-700 font-bold">
+                  <Heart size={20} /> <span>내가 보낸 따뜻한 답장</span>
+                </div>
+                <div className="text-slate-700 text-lg font-serif italic whitespace-pre-wrap">
+                  {letter.replyContent}
+                </div>
+              </div>
+            ) : (
+              <div className="bg-white/60 rounded-[3rem] p-8 md:p-10 border border-white shadow-lg">
+                <div className="flex items-center gap-3 text-sky-700 font-bold mb-6">
+                  <MessageSquareText size={20} /> <span>답장을 남겨보세요</span>
+                </div>
+                <textarea
+                  value={replyContent}
+                  onChange={handleInputChange}
+                  placeholder="따뜻한 말 한마디를 적어주세요..."
+                  className="w-full h-48 bg-white/50 rounded-2xl p-6 text-lg font-serif italic outline-none focus:ring-2 ring-sky-200 border border-slate-100 transition-all resize-none"
+                />
+                <div className="mt-6 flex justify-end">
+                  <button
+                    onClick={handleReplySubmit}
+                    disabled={isSubmitting || !replyContent.trim()}
+                    className={`flex items-center gap-2 px-8 py-4 rounded-full font-bold transition-all shadow-lg ${isSubmitting || !replyContent.trim() ? "bg-slate-200 text-slate-400" : "bg-sky-500 text-white hover:bg-sky-600"}`}
+                  >
+                    {isSubmitting ? "전송 중..." : "답장 띄워보내기"}{" "}
+                    <Send size={18} />
+                  </button>
+                </div>
+              </div>
+            )}
+          </section>
+        )}
       </main>
       <ReportCreateDialog
         key={reportDialogKey}


### PR DESCRIPTION
## 🔗 Issue 번호
- close #158 

## 🛠 작업 내역
-편지 수락(Accept) 기능 구현: 수신자가 편지를 읽고 수락 시 상태를 ACCEPTED로 변경
-편지 거절(Reject) 기능 구현: 수신자가 거절 시 해당 편지의 수신자를 초기화하고 다른 사용자에게 재할당(Reassign)하는 로직 구현
-거절(POST /api/v1/letters/{id}/reject) API 추가

## 🔄 변경 사항
-LetterService: InquiryLetterUseCase에서 상세 조회 시 자동 수락되던 로직을 제거하고, SendLetterUseCase에 명시적인 acceptLetter, rejectLetter 메서드 추가

## ✨ 새로운 기능
-수락/거절 분기 처리: 이제 사용자가 편지를 단순히 '조회'하는 것과 '수락'하는 행위가 분리되어, 수락 전까지는 답장 작성이 불가능하도록 제어합니다.
-거절 시 재매칭: 편지를 거절하면 시스템이 즉시 새로운 수신자를 찾아 편지를 다시 배달합니다.

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

