### PR TITLE
[Fix]편지 작성 검열 통과시에만 작성 제한 걸리도록 수정

### DIFF
--- a/back/src/main/java/com/back/letter/application/service/LetterService.java
+++ b/back/src/main/java/com/back/letter/application/service/LetterService.java
@@ -39,14 +39,15 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
     private final RedisTemplate<String, Object> redisTemplate;
 
     @Override
+    @Transactional
     public long createLetterAndDirectSendLetter(CreateLetterReq req, long senderId) {
-        checkSendRateLimit(senderId);
         auditContent(String.format("[제목] %s [내용] %s", req.title(), req.content()), "Letter");
+        checkSendRateLimit(senderId);
 
         return saveAndDispatch(req, senderId);
     }
 
-    @Transactional
+
     public long saveAndDispatch(CreateLetterReq req, long senderId) {
         Member sender = memberRepository.findById(senderId)
                 .orElseThrow(() -> new ServiceException("404-1", "사용자를 찾을 수 없습니다."));

--- a/back/src/main/java/com/back/letter/application/service/LetterService.java
+++ b/back/src/main/java/com/back/letter/application/service/LetterService.java
@@ -41,9 +41,13 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
     @Override
     @Transactional
     public long createLetterAndDirectSendLetter(CreateLetterReq req, long senderId) {
-        auditContent(String.format("[제목] %s [내용] %s", req.title(), req.content()), "Letter");
         checkSendRateLimit(senderId);
-
+        try {
+            auditContent(String.format("[제목] %s [내용] %s", req.title(), req.content()), "Letter");
+        } catch (ServiceException e) {
+            redisTemplate.delete("user:send:limit:" + senderId);
+            throw e;
+        }
         return saveAndDispatch(req, senderId);
     }
 


### PR DESCRIPTION
## 🔗 Issue 번호
- close #166 

## 🛠 작업 내역
-AI 검열 반려 시 적용되던 전송 제한(1분)을 롤백하는 로직 추가

## 🔄 변경 사항
-기존에는 checkSendRateLimit이 성공하면 즉시 1분간의 락이 걸렸으나, 이후 auditContent(AI 검열)에서 예외가 발생하면 사용자는 편지를 보내지 못했음에도 1분을 기다려야 하는 문제가 있었습니다.
try-catch 블록을 도입하여 AI 검열 실패(ServiceException) 시, 해당 사용자의 Redis 락 키를 즉시 삭제하도록 변경했습니다.

## ✨ 새로운 기능
-AI 검열 반려 시 즉시 재시도 가능: 부적절한 콘텐츠로 인해 발송이 거부된 경우, 사용자가 내용을 수정하여 즉시 다시 보낼 수 있습니다

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

