### PR TITLE
[Fix] ENV SPRING_PROFILES_ACTIVE=prod 삭제

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -62,8 +62,6 @@ FROM eclipse-temurin:21-jre-alpine
 ENV LANG=ko_KR.UTF-8
 ENV LC_ALL=ko_KR.UTF-8
 ENV JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8"
-ENV SPRING_PROFILES_ACTIVE=prod
-
 WORKDIR /app
 
 # Spring Boot layers (변경 빈도 낮은 순 → 높은 순으로 배치해 캐시 효율 극대화)


### PR DESCRIPTION
## 🔗 Issue 번호
- close #165

## 🛠 작업 내역
- ENV SPRING_PROFILES_ACTIVE=prod 삭제하여 k6, prod 를 하드코딩한 값이 뒤덮지 않도록 함

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

