### PR TITLE
Feat/#175 ai 기반 편지 및 답장 내용 자동 요약 기능 추가

### DIFF
--- a/back/src/main/java/com/back/censorship/adapter/in/web/dto/AuditAiResponse.java
+++ b/back/src/main/java/com/back/censorship/adapter/in/web/dto/AuditAiResponse.java
@@ -3,5 +3,6 @@ package com.back.censorship.adapter.in.web.dto;
 public record AuditAiResponse(
         boolean isPassed,
         String violationType, // PROFANITY(욕설), PERSONAL_INFO(개인정보), INSINCERE(무성의), NONE
-        String message
+        String message,
+        String summary
 ) {}

--- a/back/src/main/java/com/back/censorship/adapter/out/ai/GeminiAiAdapter.java
+++ b/back/src/main/java/com/back/censorship/adapter/out/ai/GeminiAiAdapter.java
@@ -25,7 +25,8 @@ public class GeminiAiAdapter implements AiAuditPort {
         String systemInstruction = """
             너는 익명 상담 서비스 '마음 온'의 인공지능 관리자야.
             입력된 데이터는 [제목]과 [내용]으로 구성되어 있어.
-            입력된 %s의 제목과 내용을 검사해서 반드시 아래 JSON 형식으로만 응답해.
+            입력된 %s의 제목과 내용을 검사하고, 동시에 내용을 1~2줄로 요약해줘.
+            반드시 아래 JSON 형식으로만 응답해.
             형식: {"isPassed": boolean, "violationType": "PROFANITY"|"PERSONAL_INFO"|"INSINCERE"|"NONE", "message": "사용자 안내 문구"}
             
             [기준]
@@ -41,7 +42,9 @@ public class GeminiAiAdapter implements AiAuditPort {
                 - 위반 사항이 없을 때 적용.
             [주의 사항]
                 - 안내 문구(message)는 서비스의 따뜻한 분위기에 맞춰 정중하게 작성해줘.
-                - 위반 사항이 없으면 isPassed는 true, violationType은 NONE으로 응답해.        
+                - 위반 사항이 없으면 isPassed는 true, violationType은 NONE으로 응답해. 
+                [요약 기준]
+                - 받은 사람이 내용을 한눈에 파악할 수 있게 1~2줄 내외로 따뜻하게 요약해줘.       
             """.formatted(dto.type());
 
         try {

--- a/back/src/main/java/com/back/letter/application/service/LetterService.java
+++ b/back/src/main/java/com/back/letter/application/service/LetterService.java
@@ -3,6 +3,7 @@ package com.back.letter.application.service;
 
 
 import com.back.censorship.adapter.in.web.dto.AuditAiRequest;
+import com.back.censorship.adapter.in.web.dto.AuditAiResponse;
 import com.back.censorship.application.service.AiService;
 import com.back.global.event.LetterEvents;
 import com.back.global.exception.ServiceException;
@@ -42,17 +43,19 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
     @Transactional
     public long createLetterAndDirectSendLetter(CreateLetterReq req, long senderId) {
         checkSendRateLimit(senderId);
+        AuditAiResponse response;
+
         try {
-            auditContent(String.format("[제목] %s [내용] %s", req.title(), req.content()), "Letter");
+            response = auditContent(String.format("[제목] %s [내용] %s", req.title(), req.content()), "Letter");
         } catch (ServiceException e) {
             redisTemplate.delete("user:send:limit:" + senderId);
             throw e;
         }
-        return saveAndDispatch(req, senderId);
+        return saveAndDispatch(req, senderId, response.summary());
     }
 
 
-    public long saveAndDispatch(CreateLetterReq req, long senderId) {
+    public long saveAndDispatch(CreateLetterReq req, long senderId, String summary) {
         Member sender = memberRepository.findById(senderId)
                 .orElseThrow(() -> new ServiceException("404-1", "사용자를 찾을 수 없습니다."));
 
@@ -61,6 +64,7 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
         Letter letter = Letter.builder()
                 .title(req.title())
                 .content(req.content())
+                .summary(summary)
                 .sender(sender)
                 .build();
 
@@ -77,9 +81,9 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
         Letter letter = letterPort.findById(id)
                 .orElseThrow(() -> new ServiceException("404-1", "편지를 찾을 수 없습니다."));
 
-        auditContent(req.replyContent(), "Reply");
+        AuditAiResponse response =auditContent(req.replyContent(), "Reply");
 
-        letter.reply(req.replyContent(), accessorId);
+        letter.reply(req.replyContent(), response.summary(), accessorId);
 
         letterRedisRepository.deleteWritingStatus(id);
         eventPublisher.publishEvent(new LetterEvents.LetterRepliedEvent(id, letter.getSender().getId(), accessorId));
@@ -188,9 +192,10 @@ public class LetterService implements SendLetterUseCase, InquiryLetterUseCase {
         }
     }
 
-    private void auditContent(String content, String type) {
+    private AuditAiResponse auditContent(String content, String type) {
         var response = aiService.auditContent(new AuditAiRequest(content, type));
         if (!response.isPassed()) throw new ServiceException("400-AI", response.message());
+        return response;
     }
 
     private Member findMatchingReceiver(long senderId) {

--- a/back/src/main/java/com/back/letter/domain/Letter.java
+++ b/back/src/main/java/com/back/letter/domain/Letter.java
@@ -22,7 +22,13 @@ public class Letter extends BaseEntity {
     private String content;
 
     @Column(columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(columnDefinition = "TEXT")
     private String replyContent;
+
+    @Column(columnDefinition = "TEXT")
+    private String replySummary;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -80,7 +86,7 @@ public class Letter extends BaseEntity {
     /**
      * 답장 작성 완료
      */
-    public void reply(String replyContent, long accessorId) {
+    public void reply(String replyContent, String replySummary, long accessorId) {
         verifyReceiver(accessorId);
 
         if (this.status == LetterStatus.REPLIED) {
@@ -88,6 +94,7 @@ public class Letter extends BaseEntity {
         }
 
         this.replyContent = replyContent;
+        this.replySummary = replySummary;
         this.status = LetterStatus.REPLIED;
         this.replyCreatedDate = LocalDateTime.now();
     }

--- a/back/src/test/java/com/back/censorship/application/AiServiceTest.java
+++ b/back/src/test/java/com/back/censorship/application/AiServiceTest.java
@@ -26,7 +26,7 @@ class AiServiceTest {
     private AiService aiService;
 
     private void mockAiResponse(boolean isPassed, String violationType) {
-        AuditAiResponse mockResponse = new AuditAiResponse(isPassed, violationType, "테스트 메시지");
+        AuditAiResponse mockResponse = new AuditAiResponse(isPassed, violationType, "테스트 메시지", "AI가 요약한 내용입니다.");
 
         given(aiAuditPort.audit(any(AuditAiRequest.class)))
                 .willReturn(mockResponse);

--- a/back/src/test/java/com/back/letter/service/LetterServiceTest.java
+++ b/back/src/test/java/com/back/letter/service/LetterServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -92,7 +93,7 @@ class LetterServiceTest {
 
             given(valueOperations.setIfAbsent(anyString(), any(), any(Duration.class))).willReturn(true);
             given(aiService.auditContent(any(AuditAiRequest.class)))
-                    .willReturn(new AuditAiResponse(true, "Letter", "Pass"));
+                    .willReturn(new AuditAiResponse(true, "Letter", "Pass", "가짜 요약본 내용"));
             given(memberRepository.findById(senderId)).willReturn(Optional.of(sender));
 
             // findMatchingReceiver 로직 대응
@@ -117,7 +118,7 @@ class LetterServiceTest {
             // given
             long senderId = 1L;
             given(valueOperations.setIfAbsent(anyString(), any(), any(Duration.class))).willReturn(true);
-            given(aiService.auditContent(any())).willReturn(new AuditAiResponse(true,"Letter","Pass"));
+            given(aiService.auditContent(any())).willReturn(new AuditAiResponse(true,"Letter","Pass", "가짜 요약본 내용"));
             given(memberRepository.findById(senderId)).willReturn(Optional.of(createMember(senderId, "S")));
 
             given(letterRedisRepository.getRandomReceiver()).willReturn(null);
@@ -154,16 +155,90 @@ class LetterServiceTest {
             ReflectionTestUtils.setField(letter, "id", letterId);
 
             given(letterPort.findById(letterId)).willReturn(Optional.of(letter));
-            given(aiService.auditContent(any())).willReturn(new AuditAiResponse(true,"Reply","Pass"));
+            given(aiService.auditContent(any())).willReturn(new AuditAiResponse(true,"Reply","Pass", "가짜 답장 요약본"));
 
             // when
             letterService.replyLetter(letterId, req, receiverId);
 
             // then
             assertThat(letter.getStatus()).isEqualTo(LetterStatus.REPLIED);
+            assertThat(letter.getReplySummary()).isEqualTo("가짜 답장 요약본");
             verify(letterRedisRepository).deleteWritingStatus(letterId);
             verify(eventPublisher).publishEvent(any(LetterEvents.LetterRepliedEvent.class));
         }
+    }
+
+    @Test
+    @DisplayName("성공: 편지 발송 시 AI 요약본이 함께 저장된다")
+    void givenValidRequest_whenCreateLetter_thenSaveWithSummary() {
+        // given
+        long senderId = 1L;
+        long receiverId = 2L;
+        CreateLetterReq req = new CreateLetterReq("제목", "내용");
+        String expectedSummary = "AI가 요약한 따뜻한 편지입니다."; // 🚀 가짜 요약본 설정
+
+        Member sender = createMember(senderId, "발신자");
+        Member receiver = createMember(receiverId, "수신자");
+
+        given(valueOperations.setIfAbsent(anyString(), any(), any(Duration.class))).willReturn(true);
+
+        // 🚀 수정: AI 응답에 요약본(summary) 필드를 포함시킵니다.
+        given(aiService.auditContent(any(AuditAiRequest.class)))
+                .willReturn(new AuditAiResponse(true, "NONE", "Pass", expectedSummary));
+
+        given(memberRepository.findById(senderId)).willReturn(Optional.of(sender));
+        given(letterRedisRepository.getRandomReceiver()).willReturn(receiverId);
+        given(memberRepository.findById(receiverId)).willReturn(Optional.of(receiver));
+
+        // 저장 시 반환할 가짜 객체 설정
+        Letter mockSavedLetter = Letter.builder().title("제목").build();
+        ReflectionTestUtils.setField(mockSavedLetter, "id", 100L);
+        given(letterPort.save(any(Letter.class))).willReturn(mockSavedLetter);
+
+        // when
+        letterService.createLetterAndDirectSendLetter(req, senderId);
+
+        // then
+        // 🚀 핵심: 실제로 letterPort.save()에 전달된 Letter 객체를 캡처합니다.
+        ArgumentCaptor<Letter> letterCaptor = ArgumentCaptor.forClass(Letter.class);
+        verify(letterPort).save(letterCaptor.capture());
+
+        // 🚀 검증: 캡처된 편지 객체의 요약본이 AI가 준 것과 일치하는지 확인합니다.
+        assertThat(letterCaptor.getValue().getSummary()).isEqualTo(expectedSummary);
+    }
+
+    @Test
+    @DisplayName("성공: 답장 시 AI가 생성한 답장 요약본이 저장된다")
+    void givenValidReply_whenReplyLetter_thenSaveReplySummary() {
+        // given
+        long letterId = 10L;
+        long receiverId = 2L;
+        long senderId = 1L; // 🚀 1. 발신자 ID 추가
+        String expectedReplySummary = "답장에 대한 AI 요약입니다.";
+        ReplyLetterReq req = new ReplyLetterReq("정성스러운 답장");
+
+        Member sender = createMember(senderId, "발신자"); // 🚀 2. 가짜 발신자 객체 생성
+        Member receiver = createMember(receiverId, "수신자");
+
+        Letter letter = Letter.builder()
+                .sender(sender) // 🚀 3. 핵심! 빌더에 sender를 꼭 넣어주세요.
+                .receiver(receiver)
+                .build();
+
+        letter.dispatch(receiver);
+        ReflectionTestUtils.setField(letter, "id", letterId);
+
+        given(letterPort.findById(letterId)).willReturn(Optional.of(letter));
+
+        given(aiService.auditContent(any()))
+                .willReturn(new AuditAiResponse(true, "NONE", "Pass", expectedReplySummary));
+
+        // when
+        letterService.replyLetter(letterId, req, receiverId);
+
+        // then
+        assertThat(letter.getReplySummary()).isEqualTo(expectedReplySummary);
+        assertThat(letter.getStatus()).isEqualTo(LetterStatus.REPLIED);
     }
 
     @Nested


### PR DESCRIPTION
## 🔗 Issue 번호
- close #175 

## 🛠 작업 내역
- 사용자가 편지를 주고받을 때 AI가 핵심 내용을 요약해 주는 기능을 추가했습니다.

## 🔄 변경 사항
- Letter 도메인에 최초 편지 요약(summary)과 답장 요약(replySummary) 필드를 추가했습니다.
- LetterService에서 편지 발송(create) 및 답장(reply) 시점에 AI 요약본을 챙겨서 DB에 함께 저장하도록 수정했습니다.

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

