### PR TITLE
[Fix] JWT 인증을 세션보다 우선하고 로그아웃 시 서버 세션을 무효화

### DIFF
--- a/back/src/main/java/com/back/auth/adapter/in/web/AuthController.java
+++ b/back/src/main/java/com/back/auth/adapter/in/web/AuthController.java
@@ -17,8 +17,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.Authentication;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -91,8 +94,11 @@ public class AuthController {
   public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {
     String rawRefreshToken = refreshTokenCookieService.resolveRefreshToken(request).orElse(null);
     authService.logout(rawRefreshToken);
+    invalidateServerSession(request);
+    SecurityContextHolder.clearContext();
     refreshTokenCookieService.expireRefreshTokenCookie(response);
     authHintCookieService.expireAuthHintCookie(response);
+    expireSessionCookie(response, request.getContextPath());
     return new RsData<>(
         AuthSuccessCode.LOGOUT_SUCCESS.code(), AuthSuccessCode.LOGOUT_SUCCESS.message());
   }
@@ -192,6 +198,24 @@ public class AuthController {
 
   private void issueRefreshCookie(HttpServletResponse response, String refreshToken) {
     refreshTokenCookieService.issueRefreshTokenCookie(response, refreshToken);
+  }
+
+  private void invalidateServerSession(HttpServletRequest request) {
+    var session = request.getSession(false);
+    if (session != null) {
+      session.invalidate();
+    }
+  }
+
+  private void expireSessionCookie(HttpServletResponse response, String contextPath) {
+    String cookiePath = hasContextPath(contextPath) ? contextPath : "/";
+    ResponseCookie cookie =
+        ResponseCookie.from("JSESSIONID", "")
+            .path(cookiePath)
+            .httpOnly(true)
+            .maxAge(0)
+            .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 
   private ResponseEntity<Void> redirectTo(String uri) {

--- a/back/src/main/java/com/back/global/security/adapter/in/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/back/global/security/adapter/in/JwtAuthenticationFilter.java
@@ -34,11 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
-    if (SecurityContextHolder.getContext().getAuthentication() == null) {
-      JwtTokenExtractor.extractBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION))
-            .ifPresent(token -> tryAuthenticate(token, request));
-    }
-
+    JwtTokenExtractor.extractBearerToken(request.getHeader(HttpHeaders.AUTHORIZATION))
+        .ifPresent(token -> tryAuthenticate(token, request));
 
     filterChain.doFilter(request, response);
   }

--- a/back/src/test/java/com/back/auth/adapter/in/web/AuthControllerTest.java
+++ b/back/src/test/java/com/back/auth/adapter/in/web/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.back.auth.adapter.in.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -29,6 +30,7 @@ import com.back.global.security.jwt.JwtTokenService;
 import com.back.member.domain.MemberRepository;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.mock.web.MockHttpSession;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -153,15 +155,20 @@ class AuthControllerTest {
   void logoutExpiresCookie() throws Exception {
     given(refreshTokenCookieService.resolveRefreshToken(any()))
         .willReturn(Optional.of("raw-refresh-token"));
+    MockHttpSession session = new MockHttpSession();
 
     mockMvc
-        .perform(post("/api/v1/auth/logout"))
+        .perform(post("/api/v1/auth/logout").session(session))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.resultCode").value("200-5"));
+        .andExpect(jsonPath("$.resultCode").value("200-5"))
+        .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.header()
+            .string(org.springframework.http.HttpHeaders.SET_COOKIE,
+                org.hamcrest.Matchers.containsString("JSESSIONID=; Path=/; Max-Age=0")));
 
     then(authService).should().logout("raw-refresh-token");
     then(refreshTokenCookieService).should().expireRefreshTokenCookie(any());
     then(authHintCookieService).should().expireAuthHintCookie(any());
+    assertThat(session.isInvalid()).isTrue();
   }
 
   @Test

--- a/back/src/test/java/com/back/global/security/adapter/in/JwtAuthenticationFilterTest.java
+++ b/back/src/test/java/com/back/global/security/adapter/in/JwtAuthenticationFilterTest.java
@@ -120,8 +120,33 @@ class JwtAuthenticationFilterTest {
   }
 
   @Test
-  @DisplayName("이미 인증이 설정되어 있으면 기존 SecurityContext를 유지하고 토큰을 다시 읽지 않는다")
-  void existingAuthenticationIsPreserved() throws Exception {
+  @DisplayName("이미 인증이 있어도 Bearer access 토큰이 있으면 현재 토큰 기준으로 다시 인증한다")
+  void existingAuthenticationIsOverriddenByBearerToken() throws Exception {
+    Authentication existingAuthentication =
+        new UsernamePasswordAuthenticationToken(
+            new AuthenticatedMember(99L, "existing@test.com", List.of("ROLE_USER")),
+            "existing-token",
+            List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    SecurityContextHolder.getContext().setAuthentication(existingAuthentication);
+    Member currentMember =
+        memberWithIdAndPolicy(5L, "current@test.com", MemberRole.USER, MemberStatus.ACTIVE);
+    given(jwtTokenService.validate("current-access-token")).willReturn(true);
+    given(jwtTokenService.parseAccessToken("current-access-token"))
+        .willReturn(new JwtSubject(5L, "current@test.com", List.of("ROLE_USER")));
+    given(memberRepository.findById(5L)).willReturn(Optional.of(currentMember));
+
+    doFilter("Bearer current-access-token");
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    assertThat(authentication).isNotNull();
+    assertThat(authentication).isNotSameAs(existingAuthentication);
+    assertThat(authentication.getPrincipal())
+        .isEqualTo(new AuthenticatedMember(5L, "current@test.com", List.of("ROLE_USER")));
+  }
+
+  @Test
+  @DisplayName("Authorization 헤더가 없으면 기존 SecurityContext를 유지한다")
+  void existingAuthenticationIsPreservedWithoutBearerToken() throws Exception {
     Authentication existingAuthentication =
         new UsernamePasswordAuthenticationToken(
             new AuthenticatedMember(99L, "existing@test.com", List.of("ROLE_USER")),
@@ -129,11 +154,11 @@ class JwtAuthenticationFilterTest {
             List.of(new SimpleGrantedAuthority("ROLE_USER")));
     SecurityContextHolder.getContext().setAuthentication(existingAuthentication);
 
-    doFilter("Bearer ignored-token");
+    doFilter(null);
 
     assertThat(SecurityContextHolder.getContext().getAuthentication()).isSameAs(existingAuthentication);
-    then(jwtTokenService).should(never()).validate("ignored-token");
-    then(memberRepository).should(never()).findById(org.mockito.ArgumentMatchers.anyLong());
+    then(jwtTokenService).shouldHaveNoInteractions();
+    then(memberRepository).shouldHaveNoInteractions();
   }
 
   @Test
@@ -148,7 +173,9 @@ class JwtAuthenticationFilterTest {
 
   private void doFilter(String authorizationHeader) throws Exception {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+    if (authorizationHeader != null) {
+      request.addHeader(HttpHeaders.AUTHORIZATION, authorizationHeader);
+    }
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     jwtAuthenticationFilter.doFilter(request, response, new MockFilterChain());


### PR DESCRIPTION
## 🔗 Issue 번호
- close #190

## 🛠 작업 내역
- JWT 인증을 세션보다 우선하고 로그아웃 시 서버 세션을 무효화

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

