### PR TITLE
[Fix] 리프레시 회전 대신 세션 확인으로 관리자 인증 안정화

### DIFF
--- a/back/src/main/java/com/back/auth/adapter/in/web/AuthController.java
+++ b/back/src/main/java/com/back/auth/adapter/in/web/AuthController.java
@@ -89,6 +89,17 @@ public class AuthController {
         issueResult.response());
   }
 
+  /** 현재 refresh 쿠키가 유효한지만 확인하고 access 토큰 payload를 재구성한다(회전 없음). */
+  @GetMapping("/session")
+  public RsData<AuthTokenResponse> session(HttpServletRequest request) {
+    String rawRefreshToken = refreshTokenCookieService.resolveRefreshToken(request).orElse(null);
+    AuthTokenResponse response = authService.issueSessionToken(rawRefreshToken);
+    return new RsData<>(
+        AuthSuccessCode.SESSION_SUCCESS.code(),
+        AuthSuccessCode.SESSION_SUCCESS.message(),
+        response);
+  }
+
   /** 로그아웃 API: refresh 폐기 시도 후 쿠키를 항상 만료시킨다. */
   @PostMapping("/logout")
   public RsData<Void> logout(HttpServletRequest request, HttpServletResponse response) {

--- a/back/src/main/java/com/back/auth/application/AuthService.java
+++ b/back/src/main/java/com/back/auth/application/AuthService.java
@@ -212,6 +212,12 @@ public class AuthService {
     return member;
   }
 
+  /** refresh 토큰을 회전시키지 않고 현재 세션용 access 토큰 payload를 만든다. */
+  public AuthTokenResponse issueSessionToken(String rawRefreshToken) {
+    Member member = authenticateByRefreshToken(rawRefreshToken);
+    return toTokenResponse(generateAccessToken(member), member);
+  }
+
   private JwtRefreshSubject parseRefreshSubject(String rawRefreshToken) {
     try {
       return jwtTokenService.parseRefreshToken(rawRefreshToken);

--- a/back/src/main/java/com/back/auth/application/AuthSuccessCode.java
+++ b/back/src/main/java/com/back/auth/application/AuthSuccessCode.java
@@ -5,6 +5,7 @@ public enum AuthSuccessCode {
   SIGNUP_SUCCESS("201-2", "Signed up successfully."),
   LOGIN_SUCCESS("200-3", "Logged in successfully."),
   REFRESH_SUCCESS("200-4", "Token refreshed successfully."),
+  SESSION_SUCCESS("200-7", "Session validated successfully."),
   LOGOUT_SUCCESS("200-5", "Logged out successfully."),
   ME_SUCCESS("200-6", "Current member fetched.");
 

--- a/back/src/main/java/com/back/global/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/back/global/security/config/SecurityConfig.java
@@ -119,6 +119,7 @@ public class SecurityConfig {
                       "/api/v1/admin/monitoring/auth",
                       "/api/v1/health",
                       "/api/v1/home/stats",
+                      "/api/v1/auth/session",
                       "/api/v1/posts",
                       "/api/v1/posts/*",
                       "/api/v1/auth/oidc/authorize/**",

--- a/back/src/test/java/com/back/auth/adapter/in/web/AuthControllerTest.java
+++ b/back/src/test/java/com/back/auth/adapter/in/web/AuthControllerTest.java
@@ -151,6 +151,32 @@ class AuthControllerTest {
   }
 
   @Test
+  @DisplayName("session API는 refresh 쿠키를 회전시키지 않고 현재 세션 payload를 반환한다")
+  void sessionReturnsCurrentSessionPayloadWithoutRotatingRefreshToken() throws Exception {
+    AuthTokenResponse response =
+        new AuthTokenResponse(
+            "session-access",
+            "Bearer",
+            3600L,
+            new AuthMemberResponse(3L, "admin@test.com", "admin", "ADMIN", "ACTIVE"));
+    given(refreshTokenCookieService.resolveRefreshToken(any()))
+        .willReturn(Optional.of("raw-refresh-token"));
+    given(authService.issueSessionToken("raw-refresh-token")).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/auth/session"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.resultCode").value("200-7"))
+        .andExpect(jsonPath("$.data.accessToken").value("session-access"))
+        .andExpect(jsonPath("$.data.member.role").value("ADMIN"));
+
+    then(refreshTokenCookieService).should().resolveRefreshToken(any());
+    then(authService).should().issueSessionToken("raw-refresh-token");
+    then(refreshTokenCookieService).shouldHaveNoMoreInteractions();
+    then(authHintCookieService).shouldHaveNoInteractions();
+  }
+
+  @Test
   @DisplayName("로그아웃 API는 refresh 폐기 시도 후 쿠키 만료 메서드를 호출한다")
   void logoutExpiresCookie() throws Exception {
     given(refreshTokenCookieService.resolveRefreshToken(any()))

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -1,9 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import {
-  buildSetCookieHeadersForFrontend,
-  extractCookieNameFromSetCookie,
-  extractSetCookieHeaders,
   normalizeRefreshTokenCookieHeader,
   resolveRequestHostname,
 } from "@/lib/auth/auth-proxy";
@@ -20,7 +17,7 @@ import {
 } from "@/lib/runtime/deployment-env";
 
 const BACKEND_BASE_URL = getServerApiBaseUrl();
-const REFRESH_PATH = "/api/v1/auth/refresh";
+const SESSION_PATH = "/api/v1/auth/session";
 const REFRESH_COOKIE_NAME = "refreshToken";
 const AUTH_HINT_MEMBER = "member";
 const AUTH_HINT_ADMIN = "admin";
@@ -177,7 +174,6 @@ async function fetchRefreshedSession(
   request: NextRequest,
 ): Promise<{
   authPayload: AuthTokenPayload;
-  refreshSetCookies: string[];
 } | {
   isTokenReuseDetected: boolean;
 } | null> {
@@ -188,8 +184,8 @@ async function fetchRefreshedSession(
 
   try {
     const normalizedCookieHeader = normalizeRefreshTokenCookieHeader(cookieHeader);
-    const response = await fetch(new URL(REFRESH_PATH, BACKEND_BASE_URL), {
-      method: "POST",
+    const response = await fetch(new URL(SESSION_PATH, BACKEND_BASE_URL), {
+      method: "GET",
       headers: {
         cookie: normalizedCookieHeader,
       },
@@ -197,7 +193,7 @@ async function fetchRefreshedSession(
     });
 
     if (!response.ok) {
-      if (response.status === 401) {
+      if (response.status === 401 && request.nextUrl.pathname !== "/admin") {
         try {
           const errorPayload = await response.json();
           if (errorPayload?.resultCode === "401-5") {
@@ -218,9 +214,6 @@ async function fetchRefreshedSession(
 
     return {
       authPayload: data,
-      refreshSetCookies: extractSetCookieHeaders(response.headers).filter(
-        (value) => extractCookieNameFromSetCookie(value) === REFRESH_COOKIE_NAME,
-      ),
     };
   } catch {
     return null;
@@ -309,14 +302,6 @@ export async function middleware(request: NextRequest) {
     },
   });
   setAuthHintCookie(response, hintValue, requestHostname);
-
-  for (const cookie of session.refreshSetCookies) {
-    for (const rewrittenCookie of buildSetCookieHeadersForFrontend(cookie, {
-      requestHostname,
-    })) {
-      response.headers.append("set-cookie", rewrittenCookie);
-    }
-  }
 
   return response;
 }

--- a/front/src/lib/admin/admin-dashboard-service.test.ts
+++ b/front/src/lib/admin/admin-dashboard-service.test.ts
@@ -62,16 +62,31 @@ describe("admin-dashboard-service", () => {
     await expect(getGrafanaSessionState()).resolves.toBe("ready");
   });
 
-  it("cross-origin monitor 임베드 모드에서는 same-origin probe 없이 ready를 반환한다", async () => {
+  it("명시적인 외부 monitoring URL이 있어도 same-origin probe 결과로 세션을 확인한다", async () => {
     vi.stubEnv("NODE_ENV", "production");
-    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.maum-on.parksuyeon.site");
-    const fetchMock = vi.fn();
+    vi.stubEnv(
+      "NEXT_PUBLIC_MONITORING_PROXY_URL",
+      "https://monitor.maum-on.parksuyeon.site",
+    );
+    const fetchMock = vi.fn().mockResolvedValue(
+      createJsonResponse({
+        id: 1,
+        login: "admin",
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const { getGrafanaSessionState } = await import("./admin-dashboard-service");
 
     await expect(getGrafanaSessionState()).resolves.toBe("ready");
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/grafana/api/user",
+      expect.objectContaining({
+        method: "GET",
+        cache: "no-store",
+        credentials: "include",
+      }),
+    );
   });
 
   it("Grafana 로그인 HTML이 반환되면 login-required를 반환한다", async () => {

--- a/front/src/lib/admin/admin-dashboard-service.ts
+++ b/front/src/lib/admin/admin-dashboard-service.ts
@@ -3,10 +3,7 @@ import type {
   AdminDashboardStats,
   GrafanaSessionState,
 } from "@/lib/admin/admin-dashboard-types";
-import {
-  getGrafanaSessionProbeUrl,
-  usesCrossOriginMonitoringEmbed,
-} from "@/lib/admin/grafana-dashboard";
+import { getGrafanaSessionProbeUrl } from "@/lib/admin/grafana-dashboard";
 
 const ADMIN_DASHBOARD_STATS_PATH = "/api/v1/admin/dashboard/stats";
 const MONITORING_STATUS_HEADER = "x-maum-on-monitoring-status";
@@ -17,10 +14,6 @@ export async function getAdminDashboardStats(): Promise<AdminDashboardStats> {
 }
 
 export async function getGrafanaSessionState(): Promise<GrafanaSessionState> {
-  if (usesCrossOriginMonitoringEmbed()) {
-    return "ready";
-  }
-
   try {
     const response = await fetch(getGrafanaSessionProbeUrl(), {
       method: "GET",

--- a/front/src/lib/admin/grafana-dashboard.test.ts
+++ b/front/src/lib/admin/grafana-dashboard.test.ts
@@ -42,7 +42,7 @@ describe("grafana-dashboard", () => {
     expect(url).toContain("refresh=60s");
   });
 
-  it("운영에서는 Grafana 링크를 monitor ingress로 직접 연다", async () => {
+  it("운영에서도 명시 설정이 없으면 Grafana 링크는 same-origin 경로를 유지한다", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.maum-on.parksuyeon.site");
 
@@ -53,9 +53,27 @@ describe("grafana-dashboard", () => {
       usesCrossOriginMonitoringEmbed: usesCrossOriginEmbed,
     } = await import("./grafana-dashboard");
 
+    expect(getBaseUrl()).toBe("");
+    expect(getHomeUrl()).toBe("/grafana/");
+    expect(getProbeUrl()).toBe("/grafana/api/user");
+    expect(usesCrossOriginEmbed()).toBe(false);
+  });
+
+  it("명시적인 외부 monitoring URL이 있으면 cross-origin 링크를 사용한다", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv(
+      "NEXT_PUBLIC_MONITORING_PROXY_URL",
+      "https://monitor.maum-on.parksuyeon.site/",
+    );
+
+    const {
+      getGrafanaHomeUrl: getHomeUrl,
+      getMonitoringProxyBaseUrl: getBaseUrl,
+      usesCrossOriginMonitoringEmbed: usesCrossOriginEmbed,
+    } = await import("./grafana-dashboard");
+
     expect(getBaseUrl()).toBe("https://monitor.maum-on.parksuyeon.site");
     expect(getHomeUrl()).toBe("https://monitor.maum-on.parksuyeon.site/grafana/");
-    expect(getProbeUrl()).toBe("/grafana/api/user");
     expect(usesCrossOriginEmbed()).toBe(true);
   });
 });

--- a/front/src/lib/runtime/deployment-env.test.ts
+++ b/front/src/lib/runtime/deployment-env.test.ts
@@ -80,16 +80,14 @@ describe("deployment-env", () => {
     expect(getMonitoringProxyBaseUrl()).toBe("");
   });
 
-  it("운영에서는 API 도메인 규칙으로 monitor ingress를 추론한다", async () => {
+  it("운영에서도 공개 모니터링 경로 기본값은 same-origin을 유지한다", async () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.maum-on.parksuyeon.site");
 
     const { getMonitoringProxyBaseUrl, getMonitoringProxyInternalUrl } =
       await import("./deployment-env");
 
-    expect(getMonitoringProxyBaseUrl()).toBe(
-      "https://monitor.maum-on.parksuyeon.site",
-    );
+    expect(getMonitoringProxyBaseUrl()).toBe("");
     expect(getMonitoringProxyInternalUrl()).toBe(
       "https://monitor.maum-on.parksuyeon.site",
     );

--- a/front/src/lib/runtime/deployment-env.ts
+++ b/front/src/lib/runtime/deployment-env.ts
@@ -205,11 +205,7 @@ export function getMonitoringProxyBaseUrl(): string {
   );
 
   if (!trimmed || trimmed === "/") {
-    if (process.env.NODE_ENV === "development") {
-      return "";
-    }
-
-    return inferMonitoringBaseUrlFromPublicApiBaseUrl() ?? "";
+    return "";
   }
 
   if (/^https?:\/\//i.test(trimmed)) {


### PR DESCRIPTION
## 🔗 Issue 번호
- close #217

## 🛠 작업 내역
- 리프레시 회전 대신 세션 확인으로 관리자 인증 안정화

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

