### PR TITLE
fix: 신고 처리된 숨김 게시글이 일반 화면에 노출되지 않도록 수정

### DIFF
--- a/back/src/main/java/com/back/comment/service/CommentService.java
+++ b/back/src/main/java/com/back/comment/service/CommentService.java
@@ -14,6 +14,7 @@ import com.back.member.domain.Member;
 import com.back.member.domain.MemberRepository;
 import com.back.post.application.PostErrorCode;
 import com.back.post.entity.Post;
+import com.back.post.entity.PostStatus;
 import com.back.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -45,7 +46,7 @@ public class CommentService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(AuthErrorCode.MEMBER_NOT_FOUND::toException);
 
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdAndStatusNot(postId, PostStatus.HIDDEN)
                 .orElseThrow(PostErrorCode.POST_NOT_FOUND::toException);
 
         Comment parentComment = null;
@@ -86,7 +87,7 @@ public class CommentService {
      */
     @Transactional(readOnly = true)
     public Slice<CommentInfoRes> getComments(Long postId, Pageable pageable){
-        postRepository.findById(postId)
+        postRepository.findByIdAndStatusNot(postId, PostStatus.HIDDEN)
                 .orElseThrow(PostErrorCode.POST_NOT_FOUND::toException);
 
         CommentPageCache cachedPage = commentCacheRepository.findPage(postId, pageable.getPageNumber(), pageable.getPageSize());

--- a/back/src/main/java/com/back/post/repository/PostRepository.java
+++ b/back/src/main/java/com/back/post/repository/PostRepository.java
@@ -2,6 +2,7 @@ package com.back.post.repository;
 
 import com.back.post.entity.Post;
 import com.back.post.entity.PostCategory;
+import com.back.post.entity.PostStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,6 +26,21 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     long countByTitleStartingWith(String prefix);
 
     void deleteByTitleStartingWith(String prefix);
+
+    Slice<Post> findAllByStatusNot(PostStatus status, Pageable pageable);
+
+    Slice<Post> findByTitleContainingAndStatusNot(String title, PostStatus status, Pageable pageable);
+
+    Slice<Post> findByCategoryAndStatusNot(PostCategory category, PostStatus status, Pageable pageable);
+
+    Slice<Post> findByTitleContainingAndCategoryAndStatusNot(
+            String title,
+            PostCategory category,
+            PostStatus status,
+            Pageable pageable
+    );
+
+    java.util.Optional<Post> findByIdAndStatusNot(Long id, PostStatus status);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Post p set p.viewCount = p.viewCount + :delta where p.id = :postId")

--- a/back/src/main/java/com/back/post/service/PostService.java
+++ b/back/src/main/java/com/back/post/service/PostService.java
@@ -13,6 +13,7 @@ import com.back.post.dto.PostUpdateReq;
 import com.back.post.entity.Post;
 import com.back.post.entity.PostCategory;
 import com.back.post.entity.PostResolutionStatus;
+import com.back.post.entity.PostStatus;
 import com.back.post.repository.PostRepository;
 import com.back.post.repository.PostViewCountRedisRepository;
 import lombok.RequiredArgsConstructor;
@@ -81,13 +82,14 @@ public class PostService {
         boolean hasTitle = StringUtils.hasText(title);
 
         if (hasTitle && category != null) {
-            posts = postRepository.findByTitleContainingAndCategory(title, category, pageable);
+            posts = postRepository.findByTitleContainingAndCategoryAndStatusNot(
+                    title, category, PostStatus.HIDDEN, pageable);
         } else if (hasTitle) {
-            posts = postRepository.findByTitleContaining(title, pageable);
+            posts = postRepository.findByTitleContainingAndStatusNot(title, PostStatus.HIDDEN, pageable);
         } else if (category != null) {
-            posts = postRepository.findByCategory(category, pageable);
+            posts = postRepository.findByCategoryAndStatusNot(category, PostStatus.HIDDEN, pageable);
         } else {
-            posts = postRepository.findAllBy(pageable);
+            posts = postRepository.findAllByStatusNot(PostStatus.HIDDEN, pageable);
         }
 
         return posts.map(PostListRes::from);
@@ -106,7 +108,7 @@ public class PostService {
      */
     @Transactional
     public PostInfoRes getPost(Long id) {
-        Post post = postRepository.findById(id)
+        Post post = postRepository.findByIdAndStatusNot(id, PostStatus.HIDDEN)
                 .orElseThrow(PostErrorCode.POST_NOT_FOUND::toException);
 
         long pendingViewCount = postViewCountRedisRepository.incrementViewCount(id);

--- a/back/src/test/java/com/back/comment/service/CommentServiceTest.java
+++ b/back/src/test/java/com/back/comment/service/CommentServiceTest.java
@@ -44,7 +44,7 @@ class CommentServiceTest {
     Member member = savedMember(1L, "member1@test.com", "member1");
     Post post = savedPost(10L, member);
     given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-    given(postRepository.findById(10L)).willReturn(Optional.of(post));
+    given(postRepository.findByIdAndStatusNot(10L, PostStatus.HIDDEN)).willReturn(Optional.of(post));
     given(commentRepository.save(any(Comment.class))).willAnswer(invocation -> invocation.getArgument(0));
 
     commentService.createComment(10L, 1L, new CommentCreateReq(" 댓글 내용 ", null, null));
@@ -67,7 +67,7 @@ class CommentServiceTest {
     setId(parent, 100L);
 
     given(memberRepository.findById(1L)).willReturn(Optional.of(member));
-    given(postRepository.findById(10L)).willReturn(Optional.of(requestPost));
+    given(postRepository.findByIdAndStatusNot(10L, PostStatus.HIDDEN)).willReturn(Optional.of(requestPost));
     given(commentRepository.findById(100L)).willReturn(Optional.of(parent));
 
     assertThatThrownBy(() -> commentService.createComment(10L, 1L, new CommentCreateReq("reply", null, 100L)))
@@ -120,6 +120,20 @@ class CommentServiceTest {
     commentService.deleteComment(31L, 1L);
 
     then(commentRepository).should().delete(comment);
+  }
+
+  @Test
+  @DisplayName("숨김 게시글에는 댓글을 작성할 수 없다")
+  void createCommentFailsWhenPostHidden() {
+    Member member = savedMember(1L, "member1@test.com", "member1");
+    given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+    given(postRepository.findByIdAndStatusNot(10L, PostStatus.HIDDEN)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> commentService.createComment(10L, 1L, new CommentCreateReq("댓글", null, null)))
+        .isInstanceOf(ServiceException.class)
+        .satisfies(
+            exception ->
+                assertThat(((ServiceException) exception).getRsData().resultCode()).isEqualTo("404-1"));
   }
 
   private Member savedMember(Long id, String email, String nickname) {

--- a/back/src/test/java/com/back/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/back/post/service/PostServiceTest.java
@@ -15,7 +15,10 @@ import com.back.post.dto.PostUpdateReq;
 import com.back.post.entity.Post;
 import com.back.post.entity.PostCategory;
 import com.back.post.entity.PostResolutionStatus;
+import com.back.post.entity.PostStatus;
 import com.back.post.repository.PostRepository;
+import com.back.post.repository.PostViewCountRedisRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,12 +27,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("게시글 서비스 멤버 연결 테스트")
 class PostServiceTest {
 
   @Mock private PostRepository postRepository;
+  @Mock private PostViewCountRedisRepository postViewCountRedisRepository;
   @Mock private MemberRepository memberRepository;
   @Mock private CommentRepository commentRepository;
 
@@ -145,10 +152,53 @@ class PostServiceTest {
     assertThat(post.getResolutionStatus()).isEqualTo(PostResolutionStatus.RESOLVED);
   }
 
+  @Test
+  @DisplayName("게시글 목록 조회 시 숨김 게시글은 제외한다")
+  void getPostsExcludesHiddenPosts() {
+    Pageable pageable = PageRequest.of(0, 10);
+    Member author = savedMember(1L, "member1@test.com", "member1");
+    Post visiblePost = savedPost(20L, author);
+
+    given(postRepository.findAllByStatusNot(PostStatus.HIDDEN, pageable))
+        .willReturn(new SliceImpl<>(List.of(visiblePost), pageable, false));
+
+    var result = postService.getPosts(null, null, pageable);
+
+    assertThat(result.getContent()).hasSize(1);
+    then(postRepository).should().findAllByStatusNot(PostStatus.HIDDEN, pageable);
+  }
+
+  @Test
+  @DisplayName("숨김 게시글 상세 조회는 존재하지 않는 게시글로 처리한다")
+  void getPostFailsWhenHidden() {
+    given(postRepository.findByIdAndStatusNot(21L, PostStatus.HIDDEN)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> postService.getPost(21L))
+        .isInstanceOf(ServiceException.class)
+        .satisfies(
+            exception ->
+                assertThat(((ServiceException) exception).getRsData().resultCode()).isEqualTo("404-1"));
+  }
+
   private Member savedMember(Long id, String email, String nickname) {
     Member member = Member.create(email, "$2a$10$stored", nickname);
     setId(member, id);
     return member;
+  }
+
+  private Post savedPost(Long id, Member member) {
+    Post post =
+        Post.builder()
+            .title("title")
+            .content("content")
+            .summary("content")
+            .thumbnail("thumbnail")
+            .member(member)
+            .category(PostCategory.DAILY)
+            .status(PostStatus.PUBLISHED)
+            .build();
+    setId(post, id);
+    return post;
   }
 
   private void setId(Object target, Long id) {


### PR DESCRIPTION
## 🔗 Issue 번호
- close #231 

## 🛠 작업 내역
- 관리자 신고 처리로 `HIDDEN` 상태가 된 게시글이 일반 게시글 목록/상세에서 노출되지 않도록 수정
- 숨김 처리된 게시글에는 댓글 작성 및 댓글 조회가 불가능하도록 처리
- 관련 게시글/댓글 서비스 테스트 보강 및 검증 완료


## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

