### PR TITLE
[Fix] 관리자 대시보드용 Grafana 세션 bootstrap 경로를 로그인 기반으로 정리

### DIFF
--- a/front/src/lib/admin/grafana-dashboard.test.ts
+++ b/front/src/lib/admin/grafana-dashboard.test.ts
@@ -59,7 +59,7 @@ describe("grafana-dashboard", () => {
     expect(getHomeUrl()).toBe("https://monitor.maum-on.parksuyeon.site/grafana/");
     expect(getProbeUrl()).toBe("/grafana/api/user");
     expect(getGrafanaSessionBootstrapUrl()).toBe(
-      "https://monitor.maum-on.parksuyeon.site/grafana/",
+      "https://monitor.maum-on.parksuyeon.site/grafana/login",
     );
     expect(usesCrossOriginEmbed()).toBe(true);
   });
@@ -80,7 +80,7 @@ describe("grafana-dashboard", () => {
     expect(getBaseUrl()).toBe("https://monitor.maum-on.parksuyeon.site");
     expect(getHomeUrl()).toBe("https://monitor.maum-on.parksuyeon.site/grafana/");
     expect(getGrafanaSessionBootstrapUrl()).toBe(
-      "https://monitor.maum-on.parksuyeon.site/grafana/",
+      "https://monitor.maum-on.parksuyeon.site/grafana/login",
     );
     expect(usesCrossOriginEmbed()).toBe(true);
   });

--- a/front/src/lib/admin/grafana-dashboard.ts
+++ b/front/src/lib/admin/grafana-dashboard.ts
@@ -103,7 +103,7 @@ export function getGrafanaSessionBootstrapUrl(): string | null {
     return null;
   }
 
-  return getGrafanaHomeUrl();
+  return withBasePath(`${GRAFANA_BASE_PATH}/login`);
 }
 
 export function getK6GrafanaDashboardUrl(): string {


### PR DESCRIPTION
## 🔗 Issue 번호
- close #217

## 🛠 작업 내역
- 관리자 대시보드용 Grafana 세션 bootstrap 경로를 로그인 기반으로 정리

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

