### PR TITLE
build: JUnit 테스트 커버리지 리포트 설정 추가

### DIFF
--- a/back/build.gradle.kts
+++ b/back/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     id("com.diffplug.spotless") version "8.3.0"
     id("org.springframework.boot") version "4.0.3"
     id("io.spring.dependency-management") version "1.1.7"
@@ -83,6 +84,17 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+    }
 }
 
 spotless {


### PR DESCRIPTION
## 🔗 Issue 번호
- close #236 

## 🛠 작업 내역

- JaCoCo 플러그인을 추가해 JUnit 테스트 커버리지 리포트를 생성할 수 있도록 설정
- 테스트 실행 후 HTML/XML 형식의 커버리지 리포트가 생성되도록 Gradle 태스크 구성
- 커버리지 리포트 생성 경로 확인

## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?

