### PR TITLE
Feat/popular post performance

### DIFF
--- a/back/src/main/java/com/back/comment/entity/Comment.java
+++ b/back/src/main/java/com/back/comment/entity/Comment.java
@@ -14,6 +14,8 @@ import lombok.*;
 @AllArgsConstructor
 public class Comment extends BaseEntity {
 
+    @Version
+    private Long version;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)

--- a/back/src/main/java/com/back/comment/repository/CommentRepository.java
+++ b/back/src/main/java/com/back/comment/repository/CommentRepository.java
@@ -1,15 +1,28 @@
 package com.back.comment.repository;
 
 import com.back.comment.entity.Comment;
+import jakarta.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public  interface CommentRepository extends JpaRepository<Comment, Long> {
     Slice<Comment> findByPostIdAndParentIsNull(Long postId, Pageable pageable);
 
     List<Comment> findByParentIdOrderByIdAsc(Long parentId);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("select c from Comment c where c.id = :id")
+    Optional<Comment> findWithOptimisticLockById(@Param("id") Long id);
+
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Query("select c from Comment c where c.id = :id")
+    Optional<Comment> findForReplyCreate(@Param("id") Long id);
 
     boolean existsByParent(Comment parent);
 

--- a/back/src/main/java/com/back/comment/service/CommentService.java
+++ b/back/src/main/java/com/back/comment/service/CommentService.java
@@ -54,7 +54,7 @@ public class CommentService {
         Long parentCommentId = req.parentCommentId();
 
         if (parentCommentId != null) {
-            parentComment = commentRepository.findById(parentCommentId)
+            parentComment = commentRepository.findForReplyCreate(parentCommentId)
                     .orElseThrow(CommentErrorCode.COMMENT_NOT_FOUND::toException);
 
             if (!parentComment.getPost().getId().equals(postId)) {
@@ -120,7 +120,7 @@ public class CommentService {
     @Transactional
     public void updateComment(Long commentId, Long memberId, String content) {
 
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findWithOptimisticLockById(commentId)
                 .orElseThrow(CommentErrorCode.COMMENT_NOT_FOUND::toException);
 
         if(!comment.getAuthor().getId().equals(memberId)){
@@ -147,7 +147,7 @@ public class CommentService {
     @Transactional
     public void deleteComment(Long commentId, Long memberId) {
 
-        Comment comment = commentRepository.findById(commentId)
+        Comment comment = commentRepository.findWithOptimisticLockById(commentId)
                 .orElseThrow(CommentErrorCode.COMMENT_NOT_FOUND::toException);
 
         if(!comment.getAuthor().getId().equals(memberId)){

--- a/back/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
+++ b/back/src/main/java/com/back/global/globalExceptionHandler/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
@@ -55,6 +56,15 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NoResourceFoundException.class)
   public ResponseEntity<RsData<Void>> handle(NoResourceFoundException exception) {
     return new ResponseEntity<>(new RsData<>("404-1", "Resource not found."), NOT_FOUND);
+  }
+
+  @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+  public ResponseEntity<RsData<Void>> handle(
+      ObjectOptimisticLockingFailureException exception, HttpServletRequest request) {
+    return buildResponse(
+        new RsData<>("409-3", "다른 요청이 먼저 반영되었습니다. 다시 시도해주세요."),
+        HttpStatus.CONFLICT,
+        request);
   }
 
   @ExceptionHandler(Exception.class)

--- a/back/src/main/java/com/back/global/seed/K6SeedService.java
+++ b/back/src/main/java/com/back/global/seed/K6SeedService.java
@@ -163,6 +163,7 @@ public class K6SeedService implements ApplicationRunner {
               .title(title)
               .content(content)
               .summary(content)
+              .viewCount((int) ((postCount - i) % 500))
               .status(PostStatus.PUBLISHED)
               .member(writer)
               .category(category)

--- a/back/src/main/java/com/back/post/controller/PostController.java
+++ b/back/src/main/java/com/back/post/controller/PostController.java
@@ -67,6 +67,16 @@ public class PostController implements PostApiDocs {
         return ResponseEntity.ok(new RsData<>("200-1", "Posts fetched.", data));
     }
 
+    @GetMapping("/popular")
+    public ResponseEntity<RsData<Slice<PostListRes>>> getPopularPosts(
+            @RequestParam(required = false) PostCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        Slice<PostListRes> data = postService.getPopularPosts(category, page, size);
+        return ResponseEntity.ok(new RsData<>("200-6", "Popular posts fetched.", data));
+    }
+
     /**
      * 게시글 상세 정보를 조회합니다.
      *

--- a/back/src/main/java/com/back/post/controller/docs/PostApiDocs.java
+++ b/back/src/main/java/com/back/post/controller/docs/PostApiDocs.java
@@ -72,6 +72,19 @@ public interface PostApiDocs {
       @Parameter(description = "페이지 크기") int size);
 
   @Operation(
+      summary = "인기 게시글 조회",
+      description =
+          "최근 7일간 발행된 게시글 중 조회 수가 높은 순으로 인기 게시글 목록을 조회합니다.",
+      security = {})
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+  })
+  ResponseEntity<RsData<Slice<PostListRes>>> getPopularPosts(
+      @Parameter(description = "카테고리 필터. `DAILY`, `WORRY`, `QUESTION`") PostCategory category,
+      @Parameter(description = "페이지 번호, 0부터 시작") int page,
+      @Parameter(description = "페이지 크기") int size);
+
+  @Operation(
       summary = "게시글 상세 조회",
       description = "단일 게시글의 본문, 작성자, 댓글 수 등 상세 정보를 조회합니다.",
       security = {})

--- a/back/src/main/java/com/back/post/repository/PostRepository.java
+++ b/back/src/main/java/com/back/post/repository/PostRepository.java
@@ -48,6 +48,36 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Pageable pageable
     );
 
+    @Query("""
+        SELECT p
+        FROM Post p
+        JOIN FETCH p.member m
+        WHERE p.status = :status
+          AND p.createDate >= :from
+        ORDER BY p.viewCount DESC, p.createDate DESC, p.id DESC
+        """)
+    Slice<Post> findPopularPublishedSince(
+            @Param("status") PostStatus status,
+            @Param("from") LocalDateTime from,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT p
+        FROM Post p
+        JOIN FETCH p.member m
+        WHERE p.status = :status
+          AND p.category = :category
+          AND p.createDate >= :from
+        ORDER BY p.viewCount DESC, p.createDate DESC, p.id DESC
+        """)
+    Slice<Post> findPopularPublishedSinceByCategory(
+            @Param("status") PostStatus status,
+            @Param("category") PostCategory category,
+            @Param("from") LocalDateTime from,
+            Pageable pageable
+    );
+
     java.util.Optional<Post> findByIdAndStatusNot(Long id, PostStatus status);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/back/src/main/java/com/back/post/service/PostService.java
+++ b/back/src/main/java/com/back/post/service/PostService.java
@@ -16,8 +16,11 @@ import com.back.post.entity.PostResolutionStatus;
 import com.back.post.entity.PostStatus;
 import com.back.post.repository.PostRepository;
 import com.back.post.repository.PostViewCountRedisRepository;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +30,7 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class PostService {
     private static final int SUMMARY_MAX_LENGTH = 100;
+    private static final int POPULAR_POST_LOOKBACK_DAYS = 7;
 
     private final PostRepository postRepository;
     private final PostViewCountRedisRepository postViewCountRedisRepository;
@@ -93,6 +97,40 @@ public class PostService {
         }
 
         return posts.map(PostListRes::from);
+    }
+
+    /**
+     * 최근 7일간 발행된 게시글 중 조회 수가 높은 순으로 인기 게시글을 조회합니다.
+     *
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @return 인기 게시글 Slice 응답
+     */
+    @Transactional(readOnly = true)
+    public Slice<PostListRes> getPopularPosts(PostCategory category, int page, int size) {
+        LocalDateTime from = LocalDateTime.now().minusDays(POPULAR_POST_LOOKBACK_DAYS);
+        Pageable pageable = PageRequest.of(
+                page,
+                size,
+                Sort.by(
+                        Sort.Order.desc("viewCount"),
+                        Sort.Order.desc("createDate"),
+                        Sort.Order.desc("id")
+                )
+        );
+
+        if (category == null) {
+            return postRepository.findPopularPublishedSince(PostStatus.PUBLISHED, from, pageable)
+                    .map(PostListRes::from);
+        }
+
+        return postRepository.findPopularPublishedSinceByCategory(
+                        PostStatus.PUBLISHED,
+                        category,
+                        from,
+                        pageable
+                )
+                .map(PostListRes::from);
     }
 
 

--- a/back/src/main/resources/db/migration/V5__add_comment_version.sql
+++ b/back/src/main/resources/db/migration/V5__add_comment_version.sql
@@ -1,0 +1,20 @@
+DO
+$$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
+          AND table_name = 'comment'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'comment'
+          AND column_name = 'version'
+    ) THEN
+        ALTER TABLE comment
+            ADD COLUMN version BIGINT NOT NULL DEFAULT 0;
+    END IF;
+END
+$$;

--- a/back/src/main/resources/db/migration/V6__add_popular_post_index.sql
+++ b/back/src/main/resources/db/migration/V6__add_popular_post_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_post_popular_published
+    ON post (status, category, view_count DESC, create_date DESC, id DESC);

--- a/back/src/test/java/com/back/comment/service/CommentServiceConcurrencyTest.java
+++ b/back/src/test/java/com/back/comment/service/CommentServiceConcurrencyTest.java
@@ -1,0 +1,218 @@
+package com.back.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.back.comment.dto.CommentCreateReq;
+import com.back.comment.repository.CommentCacheRepository;
+import com.back.comment.repository.CommentRepository;
+import com.back.global.exception.ServiceException;
+import com.back.member.domain.Member;
+import com.back.member.domain.MemberRepository;
+import com.back.post.entity.Post;
+import com.back.post.entity.PostCategory;
+import com.back.post.repository.PostRepository;
+import com.google.genai.Client;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DisplayName("댓글 서비스 동시성 테스트")
+class CommentServiceConcurrencyTest {
+
+  @Container
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:16-alpine")
+          .withDatabaseName("maum_on_test")
+          .withUsername("maum_on")
+          .withPassword("maum_on");
+
+  @DynamicPropertySource
+  static void registerProperties(DynamicPropertyRegistry registry) {
+    registry.add("DEV_DB_URL", postgres::getJdbcUrl);
+    registry.add("DEV_DB_USERNAME", postgres::getUsername);
+    registry.add("DEV_DB_PASSWORD", postgres::getPassword);
+  }
+
+  @Autowired private CommentService commentService;
+  @Autowired private CommentRepository commentRepository;
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private PostRepository postRepository;
+  @Autowired private PasswordEncoder passwordEncoder;
+
+  @MockitoBean private CommentCacheRepository commentCacheRepository;
+  @MockitoBean private Client geminiClient;
+
+  @Test
+  @DisplayName("같은 댓글 수정과 삭제가 동시에 들어오면 하나만 성공한다")
+  void concurrentUpdateAndDeleteAllowOnlyOneSuccess() throws Exception {
+    Member member = createMember("comment-owner");
+    Post post = createPost(member);
+    Long commentId =
+        commentService.createComment(post.getId(), member.getId(), new CommentCreateReq("before", null, null));
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    try {
+      List<Callable<AttemptResult>> tasks =
+          List.of(
+              () ->
+                  runWithBarrier(
+                      ready,
+                      start,
+                      () -> {
+                        commentService.updateComment(commentId, member.getId(), "after");
+                        return AttemptResult.success("update");
+                      }),
+              () ->
+                  runWithBarrier(
+                      ready,
+                      start,
+                      () -> {
+                        commentService.deleteComment(commentId, member.getId());
+                        return AttemptResult.success("delete");
+                      }));
+
+      List<Future<AttemptResult>> futures = new ArrayList<>();
+      for (Callable<AttemptResult> task : tasks) {
+        futures.add(executorService.submit(task));
+      }
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      List<AttemptResult> results = collectResults(futures);
+      assertThat(results.stream().filter(AttemptResult::success)).hasSize(1);
+      assertThat(results.stream().filter(result -> "OPTIMISTIC_LOCK".equals(result.errorCode))).hasSize(1);
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  @Test
+  @DisplayName("부모 댓글 삭제와 대댓글 등록이 동시에 들어오면 하나만 성공한다")
+  void concurrentDeleteAndReplyAllowOnlyOneSuccess() throws Exception {
+    Member parentAuthor = createMember("parent-owner");
+    Member replyAuthor = createMember("reply-owner");
+    Post post = createPost(parentAuthor);
+    Long parentCommentId =
+        commentService.createComment(post.getId(), parentAuthor.getId(), new CommentCreateReq("parent", null, null));
+
+    CountDownLatch ready = new CountDownLatch(2);
+    CountDownLatch start = new CountDownLatch(1);
+    ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+    try {
+      List<Callable<AttemptResult>> tasks =
+          List.of(
+              () ->
+                  runWithBarrier(
+                      ready,
+                      start,
+                      () -> {
+                        commentService.deleteComment(parentCommentId, parentAuthor.getId());
+                        return AttemptResult.success("delete");
+                      }),
+              () ->
+                  runWithBarrier(
+                      ready,
+                      start,
+                      () -> {
+                        commentService.createComment(
+                            post.getId(), replyAuthor.getId(), new CommentCreateReq("reply", null, parentCommentId));
+                        return AttemptResult.success("reply");
+                      }));
+
+      List<Future<AttemptResult>> futures = new ArrayList<>();
+      for (Callable<AttemptResult> task : tasks) {
+        futures.add(executorService.submit(task));
+      }
+
+      assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+      start.countDown();
+
+      List<AttemptResult> results = collectResults(futures);
+      assertThat(results.stream().filter(AttemptResult::success)).hasSize(1);
+      assertThat(results.stream().filter(result -> "OPTIMISTIC_LOCK".equals(result.errorCode))).hasSize(1);
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  private AttemptResult runWithBarrier(
+      CountDownLatch ready, CountDownLatch start, Callable<AttemptResult> action) throws Exception {
+    ready.countDown();
+    assertThat(start.await(5, TimeUnit.SECONDS)).isTrue();
+
+    try {
+      return action.call();
+    } catch (ObjectOptimisticLockingFailureException exception) {
+      return AttemptResult.failure("OPTIMISTIC_LOCK");
+    } catch (ServiceException exception) {
+      return AttemptResult.failure(exception.getRsData().resultCode());
+    }
+  }
+
+  private List<AttemptResult> collectResults(List<Future<AttemptResult>> futures) throws Exception {
+    List<AttemptResult> results = new ArrayList<>();
+    for (Future<AttemptResult> future : futures) {
+      results.add(future.get(10, TimeUnit.SECONDS));
+    }
+    return results;
+  }
+
+  private Member createMember(String prefix) {
+    String unique = UUID.randomUUID().toString().replace("-", "");
+    return memberRepository.saveAndFlush(
+        Member.create(
+            prefix + "-" + unique + "@test.com",
+            passwordEncoder.encode("plain-pass-1234"),
+            prefix + "-" + unique.substring(0, 8)));
+  }
+
+  private Post createPost(Member author) {
+    return postRepository.saveAndFlush(
+        Post.builder()
+            .title("title-" + UUID.randomUUID())
+            .content("content")
+            .summary("summary")
+            .thumbnail("thumbnail")
+            .member(author)
+            .category(PostCategory.DAILY)
+            .build());
+  }
+
+  private record AttemptResult(boolean success, String operation, String errorCode) {
+
+    private static AttemptResult success(String operation) {
+      return new AttemptResult(true, operation, null);
+    }
+
+    private static AttemptResult failure(String errorCode) {
+      return new AttemptResult(false, null, errorCode);
+    }
+  }
+}

--- a/back/src/test/java/com/back/comment/service/CommentServiceTest.java
+++ b/back/src/test/java/com/back/comment/service/CommentServiceTest.java
@@ -68,7 +68,7 @@ class CommentServiceTest {
 
     given(memberRepository.findById(1L)).willReturn(Optional.of(member));
     given(postRepository.findByIdAndStatusNot(10L, PostStatus.HIDDEN)).willReturn(Optional.of(requestPost));
-    given(commentRepository.findById(100L)).willReturn(Optional.of(parent));
+    given(commentRepository.findForReplyCreate(100L)).willReturn(Optional.of(parent));
 
     assertThatThrownBy(() -> commentService.createComment(10L, 1L, new CommentCreateReq("reply", null, 100L)))
         .isInstanceOf(ServiceException.class)
@@ -83,7 +83,7 @@ class CommentServiceTest {
     Member author = savedMember(1L, "member1@test.com", "member1");
     Comment comment = Comment.builder().author(author).post(savedPost(10L, author)).content("old").build();
     setId(comment, 20L);
-    given(commentRepository.findById(20L)).willReturn(Optional.of(comment));
+    given(commentRepository.findWithOptimisticLockById(20L)).willReturn(Optional.of(comment));
 
     assertThatThrownBy(() -> commentService.updateComment(20L, 2L, "new"))
         .isInstanceOf(ServiceException.class)
@@ -98,7 +98,7 @@ class CommentServiceTest {
     Member author = savedMember(1L, "member1@test.com", "member1");
     Comment comment = Comment.builder().author(author).post(savedPost(10L, author)).content("comment").build();
     setId(comment, 30L);
-    given(commentRepository.findById(30L)).willReturn(Optional.of(comment));
+    given(commentRepository.findWithOptimisticLockById(30L)).willReturn(Optional.of(comment));
     given(commentRepository.existsByParent(comment)).willReturn(true);
 
     commentService.deleteComment(30L, 1L);
@@ -114,7 +114,7 @@ class CommentServiceTest {
     Member author = savedMember(1L, "member1@test.com", "member1");
     Comment comment = Comment.builder().author(author).post(savedPost(10L, author)).content("comment").build();
     setId(comment, 31L);
-    given(commentRepository.findById(31L)).willReturn(Optional.of(comment));
+    given(commentRepository.findWithOptimisticLockById(31L)).willReturn(Optional.of(comment));
     given(commentRepository.existsByParent(comment)).willReturn(false);
 
     commentService.deleteComment(31L, 1L);

--- a/back/src/test/java/com/back/post/service/PostServiceTest.java
+++ b/back/src/test/java/com/back/post/service/PostServiceTest.java
@@ -18,6 +18,7 @@ import com.back.post.entity.PostResolutionStatus;
 import com.back.post.entity.PostStatus;
 import com.back.post.repository.PostRepository;
 import com.back.post.repository.PostViewCountRedisRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -166,6 +167,54 @@ class PostServiceTest {
 
     assertThat(result.getContent()).hasSize(1);
     then(postRepository).should().findAllByStatusNot(PostStatus.HIDDEN, pageable);
+  }
+
+  @Test
+  @DisplayName("인기 게시글 조회는 발행 상태와 최근 7일 조건으로 조회한다")
+  void getPopularPostsUsesPopularQuery() {
+    Member author = savedMember(1L, "member1@test.com", "member1");
+    Post popularPost = savedPost(30L, author);
+
+    given(postRepository.findPopularPublishedSince(
+            org.mockito.ArgumentMatchers.eq(PostStatus.PUBLISHED),
+            any(LocalDateTime.class),
+            any(Pageable.class)))
+        .willReturn(new SliceImpl<>(List.of(popularPost), PageRequest.of(0, 10), false));
+
+    var result = postService.getPopularPosts(null, 0, 10);
+
+    assertThat(result.getContent()).hasSize(1);
+    then(postRepository)
+        .should()
+        .findPopularPublishedSince(
+            org.mockito.ArgumentMatchers.eq(PostStatus.PUBLISHED),
+            any(LocalDateTime.class),
+            any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("카테고리별 인기 게시글 조회는 카테고리 조건을 포함한 쿼리를 사용한다")
+  void getPopularPostsByCategoryUsesCategoryQuery() {
+    Member author = savedMember(1L, "member1@test.com", "member1");
+    Post popularPost = savedPost(31L, author);
+
+    given(postRepository.findPopularPublishedSinceByCategory(
+            org.mockito.ArgumentMatchers.eq(PostStatus.PUBLISHED),
+            org.mockito.ArgumentMatchers.eq(PostCategory.WORRY),
+            any(LocalDateTime.class),
+            any(Pageable.class)))
+        .willReturn(new SliceImpl<>(List.of(popularPost), PageRequest.of(0, 10), false));
+
+    var result = postService.getPopularPosts(PostCategory.WORRY, 0, 10);
+
+    assertThat(result.getContent()).hasSize(1);
+    then(postRepository)
+        .should()
+        .findPopularPublishedSinceByCategory(
+            org.mockito.ArgumentMatchers.eq(PostStatus.PUBLISHED),
+            org.mockito.ArgumentMatchers.eq(PostCategory.WORRY),
+            any(LocalDateTime.class),
+            any(Pageable.class));
   }
 
   @Test


### PR DESCRIPTION
## 🔗 Issue 번호
- close #243

## 🛠 작업 내역

- 인기 게시글 조회 기능을 별도 API로 분리하고 최근 7일, 카테고리, 조회수 기준의 인기 게시글 조회 조건을 정의
- PostgreSQL EXPLAIN ANALYZE 를 통해 인기 게시글 조회 쿼리의 실행 계획을 확인하고 Parallel Seq Scan 기반 병목 구간을 분석
- status, category, viewCount, createDate, id 기준의 복합 인덱스를 설계 및 적용
- 인덱스 적용 전후 실행 계획을 비교해 Parallel Seq Scan 에서 Index Scan 으로 개선된 것을 확인
- 인기 게시글 조회 응답 시간을 단축
- 성능 검증을 위해 대량 테스트 데이터를 적재하고 카테고리 조건 기반 조회 시나리오를 구성
- 게시글 서비스 테스트를 추가해 인기 게시글 조회 로직과 카테고리별 조회 분기를 검증


## 🔄 변경 사항
-

## ✨ 새로운 기능
-

## 📦 작업 유형
- [ ] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [ ] Merge 대상 branch가 올바른가?
- [ ] Base branch가 `develope` 인가?
- [ ] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 필수 체크(`backend`, `frontend`, `codeql-java`, `codeql-javascript-typescript`, `dependency-review`) 기준을 충족하는가?
